### PR TITLE
fix(decompiler): stop Vineflower emitting invalid pattern-matching switches

### DIFF
--- a/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/FernflowerDecompiler.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/FernflowerDecompiler.java
@@ -1,15 +1,19 @@
 package com.shanebeestudios.mcdeop.processor.decompiler;
 
+import com.shanebeestudios.mcdeop.util.NativeImageUtil;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
 
 public class FernflowerDecompiler implements Decompiler {
-    private static final String[] LEGACY_OPTIONS = {
-        // Preserve native-image compatibility by avoiding runtime module probing.
-        "--include-runtime=0"
-    };
+    /**
+     * Reading the JDK's type hierarchy yields better output, but the runtime scan needs the {@code jrt} filesystem
+     * provider that native images do not ship.
+     */
+    private static String includeRuntimeOption() {
+        return NativeImageUtil.isNativeImage() ? "--include-runtime=0" : "--include-runtime=1";
+    }
 
     @Override
     public void decompile(final Path jarPath, final Path outputDir) {
@@ -18,8 +22,8 @@ public class FernflowerDecompiler implements Decompiler {
 
     @Override
     public void decompile(final Path jarPath, final Path outputDir, final List<Path> libraries) {
-        final List<String> args = new ArrayList<>(LEGACY_OPTIONS.length + libraries.size() + 2);
-        args.addAll(List.of(LEGACY_OPTIONS));
+        final List<String> args = new ArrayList<>(libraries.size() + 3);
+        args.add(includeRuntimeOption());
         for (final Path library : libraries) {
             args.add("--add-external=" + library.toAbsolutePath());
         }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/VineflowerDecompiler.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/VineflowerDecompiler.java
@@ -1,19 +1,33 @@
 package com.shanebeestudios.mcdeop.processor.decompiler;
 
+import com.shanebeestudios.mcdeop.util.NativeImageUtil;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
 
 public class VineflowerDecompiler implements Decompiler {
-    private static final String[] STABILITY_OPTIONS = {
-        "--ascii-strings=1", // Encode non-ASCII chars as escapes for consistent output
-        "--ternary-constant-simplification=0", // Disable extra rewrites that can produce invalid output
-        "--ternary-in-if=0", // Disable experimental ternary collapsing in if conditions
-        "--verify-merges=1", // Prefer safer variable merge reconstruction over cleaner-looking output
-        "--old-try-dedup=1", // Safer for obfuscated exception handlers
-        "--include-runtime=0" // Native image doesn't expose the jrt filesystem provider
+    /**
+     * Options are pinned explicitly rather than left to Vineflower's defaults because the CLI silently ignores
+     * unrecognised options: a renamed or removed option produces no diagnostic, only quietly different output.
+     */
+    private static final String[] DECOMPILER_OPTIONS = {
+        "--ascii-strings=1", // Escape non-ASCII literals so invisible codepoints stay visible in the source
+        "--ternary-constant-simplification=0", // Folding boolean ternary branches can emit invalid code
+        "--ternary-in-if=1", // Recovers the original loop conditions instead of goto-style break chains
+        "--verify-merges=0", // Troubleshooting-only switch; enabling it replaces real LVT names with varNN
+        "--old-try-dedup=0", // Inserts dummy exception handlers that break pattern-matching switches
+        "--pattern-matching=1", // Resugars `case Type t ->` switches over sealed hierarchies
+        "--decompile-switch-expressions=1" // Resugars the SwitchBootstraps.typeSwitch invokedynamic
     };
+
+    /**
+     * Letting the decompiler read the JDK's type hierarchy removes redundant casts and restores {@code @Override}
+     * annotations, but the runtime scan needs the {@code jrt} filesystem provider that native images do not ship.
+     */
+    private static String includeRuntimeOption() {
+        return NativeImageUtil.isNativeImage() ? "--include-runtime=0" : "--include-runtime=1";
+    }
 
     @Override
     public void decompile(final Path jarPath, final Path outputDir) {
@@ -22,8 +36,9 @@ public class VineflowerDecompiler implements Decompiler {
 
     @Override
     public void decompile(final Path jarPath, final Path outputDir, final List<Path> libraries) {
-        final List<String> args = new ArrayList<>(STABILITY_OPTIONS.length + libraries.size() + 2);
-        args.addAll(List.of(STABILITY_OPTIONS));
+        final List<String> args = new ArrayList<>(DECOMPILER_OPTIONS.length + libraries.size() + 3);
+        args.addAll(List.of(DECOMPILER_OPTIONS));
+        args.add(includeRuntimeOption());
         for (final Path library : libraries) {
             args.add("--add-external=" + library.toAbsolutePath());
         }

--- a/src/main/java/com/shanebeestudios/mcdeop/util/NativeImageUtil.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/util/NativeImageUtil.java
@@ -1,0 +1,19 @@
+package com.shanebeestudios.mcdeop.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NativeImageUtil {
+    private static final String IMAGE_CODE_PROPERTY = "org.graalvm.nativeimage.imagecode";
+
+    /**
+     * Whether this process is executing as a GraalVM native image.
+     *
+     * <p>Native images do not provide the {@code jrt} filesystem provider, so any feature that probes the running Java
+     * runtime for classes has to be disabled when this returns {@code true}.
+     */
+    public static boolean isNativeImage() {
+        return System.getProperty(IMAGE_CODE_PROPERTY) != null;
+    }
+}


### PR DESCRIPTION
## What

Vineflower was emitting code that is not valid Java:

```java
Throwable var43;
switch (SwitchBootstraps.typeSwitch<"typeSwitch",EndTag,ByteTag,ShortTag,IntTag,LongTag,FloatTag,DoubleTag,ByteArrayTag,StringTag,ListTag,CompoundTag,IntArrayTag,LongArrayTag>(
   var3, var4
)) {
```

`--old-try-dedup=1` was the sole cause. Upstream documents it as `[Experimental] ... inserts dummy exception handlers instead of duplicating blocks`. Those synthetic `try`/`catch (Throwable)` wrappers destroy the control-flow shape `SwitchPatternMatchProcessor` depends on, so it bails and dumps the raw `invokedynamic` rather than resugaring the pattern switch.

The comment justifying the flag — "safer for obfuscated exception handlers" — did not apply here. Minecraft is name-obfuscated, not control-flow obfuscated, and the jar is already remapped by the time the decompiler runs.

## How it was found

Bisected flag-by-flag against a real Minecraft 26.2 server jar rather than reasoned about. With only `--old-try-dedup` flipped the breakage appears; with only it removed it disappears.

Measured across all 4849 output files, before → after:

| | before | after |
|---|---|---|
| javac **parse errors** | **54** (`NbtOps`, `MacroFunction`) | **0** |
| raw `typeSwitch` | 2 | 0 |
| `$VF:` warnings | 3 | 0 |
| redundant casts | 41 | 0 |
| `@Override` | 12,496 | 13,230 |

`NbtOps.convertTo` now decompiles as intended, with record deconstruction patterns:

```java
public <U> U convertTo(final DynamicOps<U> outOps, final Tag input) {
   return (U)(switch (input) {
      case EndTag ignored -> outOps.empty();
      case ByteTag(byte value) -> outOps.createByte(value);
      ...
   });
}
```

## Option changes

- **`--old-try-dedup` → 0** — root cause. It changed only 3 files jar-wide, all for the worse; every other file was byte-identical, so the flag had no upside.
- **`--ternary-in-if` → 1** (default) — the previous `0` made exactly one file worse and none better. The default recovers the original `while (... ? ... : ...)` conditions instead of goto-style break chains.
- **`--verify-merges` → 0** (default) — upstream describes this as a troubleshooting starting point ("if there are strange variable recompilation issues, this is a good place to start"), not a quality setting. It was discarding real LVT names across 92 files (`var4` instead of `size`, `tax`, `nextIndex`) and forcing a spurious import, with no correctness gain observed.
- **Added `--pattern-matching=1`, `--decompile-switch-expressions=1`** — explicit pins on the two features this bug broke.
- **Kept** `--ascii-strings=1`, `--ternary-constant-simplification=0`.

Options are now pinned explicitly with their measured rationale, because **the Vineflower CLI silently ignores unrecognised options** — a renamed or removed flag produces no diagnostic, only quietly different output. Confirmed by passing a bogus flag. Worth re-checking on each Vineflower bump.

## GraalVM

`--include-runtime` is now resolved at runtime instead of hardcoded:

```java
return NativeImageUtil.isNativeImage() ? "--include-runtime=0" : "--include-runtime=1";
```

Letting the decompiler read the JDK type hierarchy is what removes the 41 casts and restores the 734 `@Override` annotations, but the scan needs the `jrt` filesystem provider that native images do not ship.

`NativeImageUtil` reuses the `org.graalvm.nativeimage.imagecode` property check already used by `ReconstructRemapper`, so no new dependency. Native images keep exactly their current behaviour; only the JVM/jar path gains the better output. The check is at runtime and the reachable code set is unchanged, so the native build is unaffected. Cost on the JVM: 17s → 22s.

`FernflowerDecompiler` had the same hardcoded flag with the same rationale and gets the same gate.

## Rejected after testing

- **`--variable-renaming=jad`** (restoring the `-jvn`/`-jpr` dropped in #170) — overwrites Mojang's LVT names, turning `typeId`/`count`/`type`/`list` into `b0`/`i`/`tagtype`/`listtag`. Dropping them was correct.
- **`--decompile-complex-constant-dynamic=1`** — zero effect on this jar.

## Verification

Run end to end through the app itself, not just the library: `./gradlew build` passes including spotless, and the real pipeline output has **0 parse errors** under `javac`.

## Reviewer note (out of scope)

While testing I hit what looks like a separate pre-existing bug: the negatable CLI flags appear inverted. `--no-decompile` ran decompilation; `--decompile` skipped it. That matches picocli's toggle semantics for `negatable = true` combined with `defaultValue = "true"`, which would mean `--remap`, `--decompile`, and `--zip` all currently do the opposite of their descriptions. Not touched here.
