### PR TITLE
fix(gradle-project): resolve annotation libraries missing from the manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ This section is for contributors and power users who want to run McDeob from sou
 - `--gradle-project` requires `--decompile` and `--libraries`.
 - `--decompiler` supports `vineflower` (default), `fernflower`, `cfr`, and `jadx`.
 
+The generated project also declares the annotation libraries Mojang compiles against but does not
+publish as runtime libraries, such as `org.jetbrains:annotations` and `com.google.code.findbugs:jsr305`.
+They are detected from the decompiled imports and resolved from Maven Central, pinned to the version
+that was current when the Minecraft version released. Imports that cannot be resolved are logged and
+listed in the generated `README.md`.
+
 ### Native Build (GluonFX)
 
 ```bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -264,6 +264,18 @@ buildConfig {
         },
     )
     buildConfigField(
+        "JETBRAINS_ANNOTATIONS_VERSION",
+        provider { libs.versions.jetbrainsAnnotations.get() },
+    )
+    buildConfigField(
+        "JSR305_VERSION",
+        provider { libs.versions.jsr305.get() },
+    )
+    buildConfigField(
+        "JSPECIFY_VERSION",
+        provider { libs.versions.jspecify.get() },
+    )
+    buildConfigField(
         "GITHUB_REPO_NAME",
         provider {
             getGitRepoName()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,12 @@ jadx = "1.5.6"
 slf4j = "2.0.18"
 picocli = "4.7.7"
 
+# annotations referenced by decompiled sources, only used to generate the base project.
+# these are the newest known versions; older ones are pinned per release date in the registry
+jetbrainsAnnotations = "26.0.2"
+jsr305 = "3.0.2"
+jspecify = "1.0.0"
+
 # plugins
 lombok = "9.5.0"
 spotless = "8.9.0"
@@ -26,6 +32,9 @@ jadx-java-input = { module = "io.github.skylot:jadx-java-input", version.ref = "
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }
+jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 
 [plugins]
 lombok = { id = "io.freefair.lombok", version.ref = "lombok" }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/AnnotationLibrary.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/AnnotationLibrary.java
@@ -1,0 +1,88 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * An annotation library that Mojang compiles against but does not publish as a runtime library.
+ *
+ * <p>Annotations survive into the class files and therefore into the decompiled sources, but the
+ * launcher manifest only lists what the game needs to <em>run</em>. The resulting types have to be
+ * resolved separately for the generated project to compile.
+ *
+ * @param module Maven coordinate without a version, for example {@code org.jetbrains:annotations}
+ * @param packages packages this library provides
+ * @param matchSubPackages whether packages nested below {@link #packages} also belong to it
+ * @param versions known versions, ordered newest first
+ */
+record AnnotationLibrary(String module, Set<String> packages, boolean matchSubPackages, List<Version> versions) {
+
+    /**
+     * A library version together with the date it became available on Maven Central.
+     *
+     * @param availableFrom publication date of {@link #version}
+     * @param version the Maven version string
+     */
+    record Version(LocalDate availableFrom, String version) {}
+
+    AnnotationLibrary {
+        if (packages.isEmpty()) {
+            throw new IllegalArgumentException("Annotation library " + module + " declares no packages");
+        }
+        if (versions.isEmpty()) {
+            throw new IllegalArgumentException("Annotation library " + module + " declares no versions");
+        }
+    }
+
+    /**
+     * Checks whether this library provides the given package.
+     *
+     * @param packageName fully qualified package name
+     * @return {@code true} if the package belongs to this library
+     */
+    boolean provides(final String packageName) {
+        for (final String candidate : this.packages) {
+            if (candidate.equals(packageName)) {
+                return true;
+            }
+            if (this.matchSubPackages && packageName.startsWith(candidate + ".")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Selects the newest version that already existed when the Minecraft version was released.
+     *
+     * <p>A contemporary version is the safest choice in both directions: it is guaranteed to contain
+     * every annotation the bytecode of that era could reference, and it predates later renames such
+     * as jspecify moving {@code org.jspecify.nullness} to {@code org.jspecify.annotations}. Picking
+     * the newest version instead would break old releases that reference since-renamed packages,
+     * while picking the oldest would miss annotations added over time.
+     *
+     * @param releaseDate release date of the Minecraft version
+     * @return the matching version, or the oldest known version for releases predating them all
+     */
+    String versionFor(final LocalDate releaseDate) {
+        String oldest = null;
+        for (final Version candidate : this.versions) {
+            if (!candidate.availableFrom().isAfter(releaseDate)) {
+                return candidate.version();
+            }
+            oldest = candidate.version();
+        }
+        return oldest;
+    }
+
+    /**
+     * Builds the full Maven coordinate for the given release date.
+     *
+     * @param releaseDate release date of the Minecraft version
+     * @return coordinate in {@code group:artifact:version} form
+     */
+    String coordinateFor(final LocalDate releaseDate) {
+        return this.module + ":" + this.versionFor(releaseDate);
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/AnnotationLibraryRegistry.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/AnnotationLibraryRegistry.java
@@ -1,0 +1,85 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import com.shanebeestudios.mcdeop.processor.AnnotationLibrary.Version;
+import com.shanebeestudios.mcdeop.util.GeneratedConstant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Known annotation libraries that Minecraft references without shipping them.
+ *
+ * <p>The registry is deliberately limited to libraries the decompiled sources have actually been
+ * observed to import. Packages outside it are reported as unresolved rather than guessed at, so a
+ * future annotation library surfaces as an actionable warning instead of a silently broken project.
+ *
+ * <p>The newest version of each library comes from the version catalog so Renovate keeps it current.
+ * Its {@code availableFrom} date is the publication date of the version that was current when the
+ * entry was written; a Renovate bump leaves that date slightly stale, which is harmless because the
+ * newest entry only ever applies to the newest Minecraft releases.
+ */
+final class AnnotationLibraryRegistry {
+
+    private static final List<AnnotationLibrary> LIBRARIES = List.of(
+            new AnnotationLibrary(
+                    "org.jetbrains:annotations",
+                    Set.of("org.jetbrains.annotations"),
+                    true,
+                    List.of(
+                            new Version(LocalDate.parse("2025-01-22"), GeneratedConstant.JETBRAINS_ANNOTATIONS_VERSION),
+                            new Version(LocalDate.parse("2024-09-25"), "25.0.0"),
+                            new Version(LocalDate.parse("2023-11-15"), "24.1.0"),
+                            new Version(LocalDate.parse("2023-01-11"), "24.0.0"),
+                            new Version(LocalDate.parse("2022-12-08"), "23.1.0"),
+                            new Version(LocalDate.parse("2021-11-10"), "23.0.0"),
+                            new Version(LocalDate.parse("2021-08-12"), "22.0.0"),
+                            new Version(LocalDate.parse("2021-05-25"), "21.0.1"),
+                            new Version(LocalDate.parse("2020-09-02"), "20.1.0"),
+                            new Version(LocalDate.parse("2020-02-14"), "19.0.0"),
+                            new Version(LocalDate.parse("2019-11-07"), "18.0.0"),
+                            new Version(LocalDate.parse("2019-01-30"), "17.0.0"),
+                            new Version(LocalDate.parse("2018-09-18"), "16.0.3"),
+                            new Version(LocalDate.parse("2015-10-15"), "15.0"),
+                            new Version(LocalDate.parse("2013-12-17"), "13.0"))),
+            // Matched exactly rather than by prefix: javax.annotation.processing belongs to the
+            // java.compiler module and must not pull in jsr305.
+            new AnnotationLibrary(
+                    "com.google.code.findbugs:jsr305",
+                    Set.of("javax.annotation", "javax.annotation.concurrent", "javax.annotation.meta"),
+                    false,
+                    List.of(
+                            new Version(LocalDate.parse("2017-03-31"), GeneratedConstant.JSR305_VERSION),
+                            new Version(LocalDate.parse("2015-10-09"), "3.0.1"),
+                            new Version(LocalDate.parse("2014-07-10"), "3.0.0"),
+                            new Version(LocalDate.parse("2013-12-31"), "2.0.3"),
+                            new Version(LocalDate.parse("2012-01-09"), "2.0.0"),
+                            new Version(LocalDate.parse("2009-08-24"), "1.3.9"))),
+            // Normally shipped as a runtime library. Listed so releases that reference it without
+            // shipping it still resolve, and because the date rule picks the version whose package
+            // layout matches: org.jspecify.nullness before 1.0.0, org.jspecify.annotations after.
+            new AnnotationLibrary(
+                    "org.jspecify:jspecify",
+                    Set.of("org.jspecify"),
+                    true,
+                    List.of(
+                            new Version(LocalDate.parse("2024-07-16"), GeneratedConstant.JSPECIFY_VERSION),
+                            new Version(LocalDate.parse("2022-12-13"), "0.3.0"),
+                            new Version(LocalDate.parse("2021-07-21"), "0.2.0"))));
+
+    private AnnotationLibraryRegistry() {}
+
+    /**
+     * Finds the library providing the given package.
+     *
+     * @param packageName fully qualified package name
+     * @return the matching library, or {@code null} if the package is unknown
+     */
+    static AnnotationLibrary findByPackage(final String packageName) {
+        for (final AnnotationLibrary library : LIBRARIES) {
+            if (library.provides(packageName)) {
+                return library;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/CompileDependencyResolver.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/CompileDependencyResolver.java
@@ -1,0 +1,156 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Determines which compile-time dependencies the generated project needs.
+ *
+ * <p>Rather than hardcoding a fixed set, the resolver compares what the decompiled sources import
+ * against what the downloaded libraries provide. Whatever is left over is matched against
+ * {@link AnnotationLibraryRegistry}; anything still unaccounted for is reported so a newly adopted
+ * annotation library surfaces as a warning instead of a broken build.
+ */
+@Slf4j
+final class CompileDependencyResolver {
+
+    /**
+     * Package roots owned by the JDK. Used only to keep the unresolved report free of noise, never
+     * to decide on a dependency, so a stale entry cannot cause a wrong dependency to be emitted.
+     *
+     * <p>Deliberately string-based: {@code ModuleFinder.ofSystem()} reads the JDK image, which does
+     * not exist in the GraalVM native image this tool ships as.
+     */
+    private static final Set<String> JDK_PACKAGE_ROOTS =
+            Set.of("java", "jdk", "sun", "com.sun", "org.w3c", "org.xml", "org.ietf", "netscape");
+
+    /** {@code javax} packages that look like the JDK but are published separately. */
+    private static final Set<String> NON_JDK_JAVAX_ROOTS =
+            Set.of("javax.annotation", "javax.inject", "javax.validation", "javax.servlet", "javax.persistence");
+
+    /**
+     * Packages nested below {@link #NON_JDK_JAVAX_ROOTS} that the JDK does own. {@code
+     * javax.annotation} is split: the annotation types come from jsr305, while
+     * {@code javax.annotation.processing} belongs to the {@code java.compiler} module.
+     */
+    private static final Set<String> JDK_JAVAX_EXCEPTIONS = Set.of("javax.annotation.processing");
+
+    private final DecompiledSourceScanner sourceScanner;
+    private final LibraryPackageIndex libraryPackageIndex;
+
+    CompileDependencyResolver() {
+        this.sourceScanner = new DecompiledSourceScanner();
+        this.libraryPackageIndex = new LibraryPackageIndex();
+    }
+
+    /**
+     * The compile-time dependencies a generated project needs.
+     *
+     * @param coordinates Maven coordinates to declare, in {@code group:artifact:version} form
+     * @param unresolvedPackages imported packages that neither the libraries nor the registry cover
+     */
+    record CompileDependencies(List<String> coordinates, List<String> unresolvedPackages) {}
+
+    /**
+     * Resolves the compile-time dependencies for a decompiled Minecraft version.
+     *
+     * @param decompiledRoot directory containing the decompiled sources
+     * @param librariesRoot directory containing the downloaded libraries
+     * @param releaseDate release date of the Minecraft version, used to pick contemporary versions
+     * @return the dependencies to declare and any packages left unresolved
+     * @throws IOException if the sources or libraries cannot be read
+     */
+    CompileDependencies resolve(final Path decompiledRoot, final Path librariesRoot, final LocalDate releaseDate)
+            throws IOException {
+        final DecompiledSourceScanner.ScanResult sources = this.sourceScanner.scan(decompiledRoot);
+        final Set<String> providedPackages = this.libraryPackageIndex.index(librariesRoot);
+
+        final Set<String> coordinates = new LinkedHashSet<>();
+        final List<String> unresolved = new ArrayList<>();
+
+        final List<String> importedPackages = new ArrayList<>(sources.importedPackages());
+        Collections.sort(importedPackages);
+
+        for (final String importedPackage : importedPackages) {
+            if (importedPackage.isEmpty()
+                    || sources.declaredPackages().contains(importedPackage)
+                    || providedPackages.contains(importedPackage)) {
+                continue;
+            }
+
+            // The registry is consulted before the JDK heuristic so a known library always wins.
+            final AnnotationLibrary library = AnnotationLibraryRegistry.findByPackage(importedPackage);
+            if (library != null) {
+                coordinates.add(library.coordinateFor(releaseDate));
+                continue;
+            }
+            if (isJdkPackage(importedPackage)) {
+                continue;
+            }
+
+            unresolved.add(importedPackage);
+        }
+
+        this.report(coordinates, unresolved);
+        return new CompileDependencies(List.copyOf(coordinates), List.copyOf(unresolved));
+    }
+
+    /**
+     * Logs the outcome so a missing mapping is visible without inspecting the generated project.
+     *
+     * @param coordinates resolved Maven coordinates
+     * @param unresolved packages without a known source
+     */
+    private void report(final Set<String> coordinates, final List<String> unresolved) {
+        if (coordinates.isEmpty()) {
+            log.info("Decompiled sources need no additional compile-time dependencies.");
+        } else {
+            log.info("Resolved {} compile-time dependencies: {}", coordinates.size(), String.join(", ", coordinates));
+        }
+
+        if (!unresolved.isEmpty()) {
+            log.warn(
+                    "{} imported package(s) could not be resolved and are missing from the generated project: {}."
+                            + " They are neither provided by the downloaded libraries nor known to McDeob;"
+                            + " add the matching dependencies manually.",
+                    unresolved.size(),
+                    String.join(", ", unresolved));
+        }
+    }
+
+    /**
+     * Best-effort check for whether a package belongs to the JDK.
+     *
+     * @param packageName fully qualified package name
+     * @return {@code true} if the package is most likely part of the JDK
+     */
+    private static boolean isJdkPackage(final String packageName) {
+        for (final String root : JDK_PACKAGE_ROOTS) {
+            if (packageName.equals(root) || packageName.startsWith(root + ".")) {
+                return true;
+            }
+        }
+
+        if (!packageName.startsWith("javax.")) {
+            return false;
+        }
+        for (final String exception : JDK_JAVAX_EXCEPTIONS) {
+            if (packageName.equals(exception) || packageName.startsWith(exception + ".")) {
+                return true;
+            }
+        }
+        for (final String root : NON_JDK_JAVAX_ROOTS) {
+            if (packageName.equals(root) || packageName.startsWith(root + ".")) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/DecompiledSourceScanner.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/DecompiledSourceScanner.java
@@ -1,0 +1,199 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Collects the packages a decompiled source tree imports and declares.
+ *
+ * <p>Only the header of each file is read. Parsing stops at the first type declaration, so the bulk
+ * of the sources is never touched.
+ */
+final class DecompiledSourceScanner {
+
+    /** Guards against reading an entire file should a header never terminate as expected. */
+    private static final int MAX_HEADER_LINES = 512;
+
+    private static final String JAVA_SUFFIX = ".java";
+    private static final String IMPORT_KEYWORD = "import ";
+    private static final String STATIC_KEYWORD = "static ";
+
+    /** Byte order mark, stripped so a marked file does not hide its own import block. */
+    private static final char BYTE_ORDER_MARK = '﻿';
+
+    /**
+     * Marks the end of the header. Anything else before the first type is skipped rather than
+     * treated as a terminator, so unexpected content cannot silently suppress import detection.
+     */
+    private static final Pattern TYPE_DECLARATION =
+            Pattern.compile("\\b(?:class|interface|enum|record)\\s+\\w|\\b(?:class|interface|enum|record)$");
+
+    /**
+     * The packages a source tree imports and the packages it declares itself.
+     *
+     * @param importedPackages packages referenced by import statements
+     * @param declaredPackages packages the tree defines, derived from the directory layout
+     */
+    record ScanResult(Set<String> importedPackages, Set<String> declaredPackages) {}
+
+    /**
+     * Scans a decompiled source tree.
+     *
+     * @param root directory containing the decompiled sources
+     * @return the imported and declared packages
+     * @throws IOException if the tree cannot be read
+     */
+    ScanResult scan(final Path root) throws IOException {
+        final Set<String> imported = new HashSet<>();
+        final Set<String> declared = new HashSet<>();
+
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes) throws IOException {
+                if (!file.getFileName().toString().endsWith(JAVA_SUFFIX)) {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                declared.add(declaredPackageOf(root, file));
+                collectImports(file, imported);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        return new ScanResult(imported, declared);
+    }
+
+    /**
+     * Derives the package a source file belongs to from its location in the tree.
+     *
+     * <p>The directory layout is used rather than the {@code package} statement because decompiled
+     * output is always written to matching directories, and it avoids a second parse.
+     *
+     * @param root root of the source tree
+     * @param file the source file
+     * @return the declared package, empty for the default package
+     */
+    private static String declaredPackageOf(final Path root, final Path file) {
+        final Path parent = root.relativize(file).getParent();
+        if (parent == null) {
+            return "";
+        }
+        return parent.toString().replace('\\', '.').replace('/', '.');
+    }
+
+    /**
+     * Reads the import statements from a file header.
+     *
+     * @param file the source file
+     * @param target set collecting the imported packages
+     * @throws IOException if the file cannot be read
+     */
+    private static void collectImports(final Path file, final Set<String> target) throws IOException {
+        try (final BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            boolean inBlockComment = false;
+
+            for (int lineNumber = 0; lineNumber < MAX_HEADER_LINES; lineNumber++) {
+                final String rawLine = reader.readLine();
+                if (rawLine == null) {
+                    return;
+                }
+
+                final String line = (lineNumber == 0 ? stripByteOrderMark(rawLine) : rawLine).trim();
+                if (inBlockComment) {
+                    inBlockComment = !line.endsWith("*/");
+                    continue;
+                }
+                if (line.startsWith("/*")) {
+                    inBlockComment = !line.endsWith("*/");
+                    continue;
+                }
+                // Skipped before the terminator check: decompiler banners mention ".class files"
+                // and would otherwise read as a type declaration.
+                if (line.isEmpty() || line.startsWith("//")) {
+                    continue;
+                }
+                if (line.startsWith(IMPORT_KEYWORD)) {
+                    final String importedPackage = packageOfImport(line);
+                    if (!importedPackage.isEmpty()) {
+                        target.add(importedPackage);
+                    }
+                    continue;
+                }
+                // The first type declaration ends the header. Everything before it, including the
+                // package statement and any annotations preceding it in package-info files, is
+                // skipped without assuming a fixed layout.
+                if (TYPE_DECLARATION.matcher(line).find()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Removes a leading byte order mark.
+     *
+     * @param line the first line of a file
+     * @return the line without its byte order mark
+     */
+    private static String stripByteOrderMark(final String line) {
+        return !line.isEmpty() && line.charAt(0) == BYTE_ORDER_MARK ? line.substring(1) : line;
+    }
+
+    /**
+     * Extracts the package name from a single import statement.
+     *
+     * @param line a trimmed line starting with {@code import}
+     * @return the imported package, empty if the statement cannot be parsed
+     */
+    private static String packageOfImport(final String line) {
+        String reference = line.substring(IMPORT_KEYWORD.length()).trim();
+        if (reference.startsWith(STATIC_KEYWORD)) {
+            reference = reference.substring(STATIC_KEYWORD.length()).trim();
+        }
+
+        final int terminator = reference.indexOf(';');
+        if (terminator < 0) {
+            return "";
+        }
+        reference = reference.substring(0, terminator).trim();
+        if (reference.endsWith(".*")) {
+            reference = reference.substring(0, reference.length() - 2);
+        }
+
+        return packagePrefixOf(reference);
+    }
+
+    /**
+     * Takes the leading lowercase segments of a type reference, which form its package.
+     *
+     * <p>This resolves nested types and static members without a symbol table:
+     * {@code org.jetbrains.annotations.ApiStatus.Internal} yields {@code org.jetbrains.annotations}.
+     *
+     * @param reference a fully qualified reference
+     * @return the package portion
+     */
+    private static String packagePrefixOf(final String reference) {
+        final StringBuilder builder = new StringBuilder(reference.length());
+
+        for (final String segment : reference.split("\\.")) {
+            if (segment.isEmpty() || !Character.isLowerCase(segment.charAt(0))) {
+                break;
+            }
+            if (!builder.isEmpty()) {
+                builder.append('.');
+            }
+            builder.append(segment);
+        }
+
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/GradleProjectWriter.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/GradleProjectWriter.java
@@ -1,9 +1,12 @@
 package com.shanebeestudios.mcdeop.processor;
 
+import com.shanebeestudios.mcdeop.processor.CompileDependencyResolver.CompileDependencies;
 import com.shanebeestudios.mcdeop.util.FileUtil;
 import com.shanebeestudios.mcdeop.util.GeneratedConstant;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -11,7 +14,6 @@ import java.util.Set;
 
 final class GradleProjectWriter {
     private static final int DEFAULT_GRADLE_JAVA_VERSION = 21;
-    private static final String FOOJAY_RESOLVER_PLUGIN_VERSION = "1.0.0";
 
     private static final String SETTINGS_TEMPLATE = """
         pluginManagement {
@@ -28,6 +30,8 @@ final class GradleProjectWriter {
         rootProject.name = "{{projectName}}"
         """;
 
+    // The compile-only dependencies are rendered with their own indentation and trailing newline,
+    // so the placeholder sits inline to keep the block tidy when there is nothing to add.
     private static final String BUILD_TEMPLATE = """
         plugins {
             java
@@ -57,7 +61,7 @@ final class GradleProjectWriter {
         }
 
         dependencies {
-            implementation(fileTree("../libraries") {
+        {{compileOnlyDependencies}}    implementation(fileTree("../libraries") {
                 include("**/*.jar")
                 exclude("**/*-natives-*.jar")
             })
@@ -109,20 +113,34 @@ final class GradleProjectWriter {
         This project compiles against:
         - Decompiled sources in `../decompiled`
         - Downloaded libraries in `../libraries`
+        - Annotation libraries resolved from Maven Central, which Mojang compiles against but does
+          not ship as runtime libraries
 
         Run:
         `gradle build`
         {{#application}}`gradle runMinecraft`{{/application}}
+        {{#unresolved}}
+
+        ## Unresolved imports
+
+        The following packages are imported by the decompiled sources but are provided neither by
+        `../libraries` nor by any dependency McDeob knows about. Add the matching dependencies to
+        `build.gradle.kts` manually:
+
+        {{unresolvedPackages}}
+        {{/unresolved}}
         """;
 
     private final ResourceRequest request;
     private final ProcessorPaths paths;
     private final SimpleTemplateEngine templateEngine;
+    private final CompileDependencyResolver dependencyResolver;
 
     GradleProjectWriter(final ResourceRequest request, final ProcessorPaths paths) {
         this.request = request;
         this.paths = paths;
         this.templateEngine = new SimpleTemplateEngine();
+        this.dependencyResolver = new CompileDependencyResolver();
     }
 
     void setupGradleProject() throws IOException {
@@ -134,12 +152,17 @@ final class GradleProjectWriter {
             throw new IOException("Libraries directory was not found: " + this.paths.librariesPath());
         }
 
+        final CompileDependencies dependencies = this.dependencyResolver.resolve(
+                this.paths.decompiledJarPath(),
+                this.paths.librariesPath(),
+                this.request.getVersion().releaseTime().toLocalDate());
+
         FileUtil.remove(this.paths.gradleProjectPath());
         Files.createDirectories(this.paths.gradleProjectPath());
-        this.writeGradleProjectFiles();
+        this.writeGradleProjectFiles(dependencies);
     }
 
-    private void writeGradleProjectFiles() throws IOException {
+    private void writeGradleProjectFiles(final CompileDependencies dependencies) throws IOException {
         final String projectName = String.format(
                 "minecraft-%s-%s",
                 this.request.type().name().toLowerCase(Locale.ENGLISH),
@@ -147,17 +170,25 @@ final class GradleProjectWriter {
         final String minecraftVersion = this.request.getVersion().id();
         final int javaVersion = this.request.getJavaVersion().orElse(DEFAULT_GRADLE_JAVA_VERSION);
         final Optional<String> mainClass = this.request.getMainClass();
-        final boolean hasMainClass = mainClass.isPresent();
 
-        final Map<String, String> values = Map.of(
-                "foojayVersion", GeneratedConstant.FOOJAY_RESOLVER_VERSION,
-                "projectName", this.escapeKotlinString(projectName),
-                "minecraftVersion", this.escapeKotlinString(minecraftVersion),
-                "minecraftVersionRaw", minecraftVersion,
-                "javaVersion", Integer.toString(javaVersion),
-                "mainClass", mainClass.map(this::escapeKotlinString).orElse(""),
-                "mainClassRaw", mainClass.orElse("n/a"));
-        final Set<String> sections = hasMainClass ? Set.of("application") : Set.of();
+        final Map<String, String> values = Map.ofEntries(
+                Map.entry("foojayVersion", GeneratedConstant.FOOJAY_RESOLVER_VERSION),
+                Map.entry("projectName", this.escapeKotlinString(projectName)),
+                Map.entry("minecraftVersion", this.escapeKotlinString(minecraftVersion)),
+                Map.entry("minecraftVersionRaw", minecraftVersion),
+                Map.entry("javaVersion", Integer.toString(javaVersion)),
+                Map.entry("mainClass", mainClass.map(this::escapeKotlinString).orElse("")),
+                Map.entry("mainClassRaw", mainClass.orElse("n/a")),
+                Map.entry("compileOnlyDependencies", this.renderCompileOnlyDependencies(dependencies.coordinates())),
+                Map.entry("unresolvedPackages", this.renderUnresolvedPackages(dependencies.unresolvedPackages())));
+
+        final Set<String> sections = new HashSet<>();
+        if (mainClass.isPresent()) {
+            sections.add("application");
+        }
+        if (!dependencies.unresolvedPackages().isEmpty()) {
+            sections.add("unresolved");
+        }
 
         Files.writeString(
                 this.paths.gradleProjectPath().resolve("settings.gradle.kts"),
@@ -170,6 +201,47 @@ final class GradleProjectWriter {
         Files.writeString(
                 this.paths.gradleProjectPath().resolve("README.md"),
                 this.templateEngine.render(README_TEMPLATE, values, sections));
+    }
+
+    /**
+     * Renders the {@code compileOnly} declarations for the resolved annotation libraries.
+     *
+     * @param coordinates Maven coordinates to declare
+     * @return an indented block ending in a blank line, or an empty string when nothing is needed
+     */
+    private String renderCompileOnlyDependencies(final List<String> coordinates) {
+        if (coordinates.isEmpty()) {
+            return "";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("    // Mojang compiles against these annotations, so they appear in the decompiled\n")
+                .append("    // sources, but they are not shipped as runtime libraries and are therefore\n")
+                .append("    // missing from ../libraries. Versions match this Minecraft release's date.\n");
+        for (final String coordinate : coordinates) {
+            builder.append("    compileOnly(\"").append(coordinate).append("\")\n");
+        }
+
+        return builder.append('\n').toString();
+    }
+
+    /**
+     * Renders the unresolved packages as a Markdown list for the generated README.
+     *
+     * @param packages packages without a known source
+     * @return a Markdown list, or an empty string when everything resolved
+     */
+    private String renderUnresolvedPackages(final List<String> packages) {
+        if (packages.isEmpty()) {
+            return "";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        for (final String packageName : packages) {
+            builder.append("- `").append(packageName).append("`\n");
+        }
+
+        return builder.toString().stripTrailing();
     }
 
     private String escapeKotlinString(final String value) {

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/LibraryPackageIndex.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/LibraryPackageIndex.java
@@ -1,0 +1,105 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Indexes the packages provided by the downloaded Minecraft libraries.
+ *
+ * <p>Only the archive directories are read, not the entries themselves, so indexing stays cheap even
+ * across the full library set.
+ */
+@Slf4j
+final class LibraryPackageIndex {
+
+    private static final String JAR_SUFFIX = ".jar";
+    private static final String CLASS_SUFFIX = ".class";
+
+    /**
+     * Marks platform natives, which the generated project puts on the runtime classpath only. They
+     * are excluded here so the index reflects what is actually visible at compile time.
+     */
+    private static final String NATIVES_MARKER = "-natives-";
+
+    /**
+     * Indexes every compile-visible library jar below the given directory.
+     *
+     * @param root directory holding the downloaded libraries
+     * @return packages provided by those libraries
+     * @throws IOException if the directory cannot be walked
+     */
+    Set<String> index(final Path root) throws IOException {
+        final Set<String> packages = new HashSet<>();
+        if (!Files.isDirectory(root)) {
+            return packages;
+        }
+
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes) {
+                if (isCompileVisibleJar(file)) {
+                    indexJar(file, packages);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        return packages;
+    }
+
+    /**
+     * Checks whether a file is a library jar that ends up on the compile classpath.
+     *
+     * @param file candidate file
+     * @return {@code true} for non-natives jars
+     */
+    private static boolean isCompileVisibleJar(final Path file) {
+        final String fileName = file.getFileName().toString().toLowerCase(Locale.ENGLISH);
+        return fileName.endsWith(JAR_SUFFIX) && !fileName.contains(NATIVES_MARKER);
+    }
+
+    /**
+     * Adds the packages of a single jar to the index.
+     *
+     * <p>A damaged archive is logged and skipped rather than failing project generation; the only
+     * consequence is that a dependency may be reported as unresolved.
+     *
+     * @param file the jar to read
+     * @param target set collecting the provided packages
+     */
+    private static void indexJar(final Path file, final Set<String> target) {
+        try (final ZipFile archive = new ZipFile(file.toFile())) {
+            final Enumeration<? extends ZipEntry> entries = archive.entries();
+
+            while (entries.hasMoreElements()) {
+                final ZipEntry entry = entries.nextElement();
+                if (entry.isDirectory()) {
+                    continue;
+                }
+
+                final String name = entry.getName();
+                if (!name.endsWith(CLASS_SUFFIX)) {
+                    continue;
+                }
+
+                final int lastSeparator = name.lastIndexOf('/');
+                if (lastSeparator > 0) {
+                    target.add(name.substring(0, lastSeparator).replace('/', '.'));
+                }
+            }
+        } catch (final IOException exception) {
+            log.warn("Failed to index library jar {}; its packages may be reported as unresolved.", file, exception);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The generated Gradle project failed to compile:

```
decompiled/net/minecraft/core/Vec3i.java:8: error: package javax.annotation.concurrent does not exist
import javax.annotation.concurrent.Immutable;
```

Mojang compiles against annotation libraries that the launcher manifest does not list, because the manifest only enumerates what the game needs to **run**. The annotations survive into the class files and therefore into the decompiled sources, but no jar ever lands in `libraries/`.

Two things were ruled out first:

- **The manifest never had them.** All 905 versions in `version_manifest.json` were fetched and scanned (0 failures): zero occurrences of `com.google.code.findbugs:jsr305` and zero of `org.jetbrains:annotations`, from `rd-132211` through `26.3-snapshot-6`. The only annotation library Mojang ships is `org.jspecify:jspecify`.
- **The download path drops nothing.** For `26.3-snapshot-6` the manifest lists 131 libraries, all 131 have a `downloads.artifact.url`, and all 131 land on disk. `LauncherMeta#mapLibrary` applies no name or rules filter.

## Approach

Rather than hardcoding a fixed set — which would encode one version's annotation set and silently break when Mojang switches again — the dependencies are derived from the decompiled output:

```
imported packages (source headers)
  − packages provided by the downloaded jars
  − packages the decompiled tree declares itself
= unresolved → matched against a registry of known annotation libraries
```

Anything matching nothing is logged as a warning and listed in the generated `README.md`, so a newly adopted annotation library becomes an actionable message instead of a broken project.

### Version selection by release date

Versions are pinned to what was current when the Minecraft version released. A contemporary artifact is safe in both directions: it contains every annotation that era's bytecode could reference, and it predates later renames.

This matters concretely — `ApiStatus` did not exist before `annotations:19.0` (2020), and jspecify moved `org.jspecify.nullness` to `org.jspecify.annotations` in 1.0.0. Bytecode level is *not* the constraint: `annotations:15.0`+ is already Java 8 bytecode and no generated project targets below 8.

Newest versions live in the version catalog so Renovate keeps them current; older ones are static historical pins.

### GraalVM native image

Detection deliberately avoids `ModuleFinder.ofSystem()` (reads the JDK module image, absent in a native image) and `ModuleLayer.boot()` (only sees included modules). No new reflection or resource config is required. The JDK-package check is pure string logic and is used **only** to keep the unresolved report free of noise — never to decide on a dependency, so a stale entry cannot emit a wrong dependency.

## Verification

Real `26.3-snapshot-6` run — 7,148 sources, 131 jars, resolved in under a second:

```
Resolved 2 compile-time dependencies:
  com.google.code.findbugs:jsr305:3.0.2, org.jetbrains:annotations:26.0.2
```

Compiling the generated project, with the javac error cap lifted so no category is crowded out:

| | total errors | `package does not exist` |
|---|---|---|
| without the resolved deps | 464 | **44** |
| with them | 356 | **0** |

The 44 were exactly `javax.annotation`, `javax.annotation.concurrent`, `org.jetbrains.annotations` and `org.jetbrains.annotations.ApiStatus`. The remaining 356 are pre-existing Vineflower decompilation artifacts (duplicate locals, generic inference) and are out of scope here.

Date selection was checked across a fixture spanning six release dates:

| release | resolved |
|---|---|
| 2026-08-06 | `jsr305:3.0.2`, `annotations:26.0.2` |
| 2024-01-15 | `jsr305:3.0.2`, `annotations:24.1.0` |
| 2021-01-01 | `jsr305:3.0.2`, `annotations:20.1.0` |
| 2019-06-01 | `jsr305:3.0.2`, `annotations:17.0.0` |
| 2014-01-01 | `jsr305:2.0.3`, `annotations:13.0` |
| 2011-01-01 | `jsr305:1.3.9`, `annotations:13.0` (floor) |

The same fixture confirms packages already provided by a jar are skipped, natives jars are excluded from the index, `javax.annotation.processing` is treated as JDK rather than pulling in jsr305, and an unknown package is reported instead of guessed at.

## Note

There is no test infrastructure in this repository, so this was verified with a throwaway harness and a real end-to-end run rather than committed tests. The date-selection and import-parsing logic is pure and would suit unit tests — happy to add JUnit in a follow-up if you want that.
