### PR TITLE
feat(source-repair): repair the defects decompilers leave in their output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ files.
 4. In the UI:
     - Choose `Client` or `Server`
     - Pick a Minecraft version
-    - Enable the options you want (`Remap`, `Decompile`, `Zip`)
+    - Enable the options you want (`Remap`, `Decompile`, `Zip`, `Repair Sources`)
     - Click start and wait for completion
 5. Open the output folder shown by the app.
 
@@ -71,6 +71,34 @@ This section is for contributors and power users who want to run McDeob from sou
 
 - `--gradle-project` requires `--decompile` and `--libraries`.
 - `--decompiler` supports `vineflower` (default), `fernflower`, `cfr`, and `jadx`.
+
+### Source Repair
+
+Decompilers describe what a class file does, not the source it was compiled from. Wherever the
+compiler erased something the two differ, and the output stops being a legal Java program: casts
+between two parameterisations of a type leave no trace in the bytecode and are dropped, variables
+that lived in separate scopes collide once those scopes are merged, and desugared record patterns
+leave temporaries with no declaration.
+
+`--repair-sources` type-checks the decompiled tree and repairs what the compiler rejects, one class
+of defect at a time, until it compiles or nothing more is within reach. It is on by default with
+`--gradle-project`, which is the mode whose output is meant to build, and can be turned off with
+`--no-repair-sources`.
+
+```bash
+./gradlew run --args="--type client --version 1.21.4 --decompile --libraries --repair-sources"
+```
+
+- Requires `--decompile` and `--libraries`; type-checking needs both the sources and what they
+  compile against.
+- Requires a JDK at least as new as the release the sources target. Running on a JDK it is used
+  directly; a native image has no compiler of its own and borrows one from `JAVA_HOME`, the `PATH`,
+  or a Gradle toolchain under `~/.gradle/jdks`.
+- Errors that no repair covers are logged and left in place, so a version that hits an unfamiliar
+  defect still produces output.
+- Note that a native image also decompiles without the JDK type hierarchy, because the `jrt`
+  filesystem it needs is not available there. That yields noticeably more defects to begin with than
+  a `.jar` run does, so a `.jar` run gives the best chance of a project that builds.
 
 The generated project also declares the annotation libraries Mojang compiles against but does not
 publish as runtime libraries, such as `org.jetbrains:annotations` and `com.google.code.findbugs:jsr305`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ repositories {
 dependencies {
     implementation(project(":common", "shadow"))
     implementation(project(":launchermeta", "shadow"))
+    implementation(project(":sourcerepair", "shadow"))
     implementation(libs.reconstruct.common)
     implementation(libs.vineflower)
     implementation(libs.jadx.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ reconstruct-common = { module = "io.github.lxgaming:reconstruct-common", version
 vineflower = { module = "org.vineflower:vineflower", version.ref = "vineflower" }
 jadx-core = { module = "io.github.skylot:jadx-core", version.ref = "jadx" }
 jadx-java-input = { module = "io.github.skylot:jadx-java-input", version.ref = "jadx" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,4 +11,4 @@ plugins {
 
 rootProject.name = "McDeob"
 
-include("common", "launchermeta")
+include("common", "launchermeta", "sourcerepair")

--- a/sourcerepair/build.gradle.kts
+++ b/sourcerepair/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    implementation(libs.slf4j.api)
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/ArgumentCastRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/ArgumentCastRepair.java
@@ -1,0 +1,98 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.regex.Pattern;
+
+/**
+ * Removes a cast the decompiler added that stops its call from resolving.
+ *
+ * <p>Where a call's type arguments were inferred, a decompiler has to write down the types erasure
+ * left it with, and it does so by casting the arguments. Those casts pin each argument to what the
+ * bytecode records, which is the <em>result</em> of the original inference rather than its input.
+ * Inference is then left with nothing to work out and the call no longer resolves.
+ *
+ * <p>Dropping the cast restores what the source said. The compiler is what identifies the call as
+ * unresolvable in the first place, so only calls that are already broken are touched, and a removal
+ * that does not help is undone along with the rest of its file.
+ */
+final class ArgumentCastRepair implements SourceRepair {
+
+    /** Errors that mean a call could not be resolved against its arguments. */
+    private static final Pattern UNRESOLVED_CALL = Pattern.compile(
+            "^(?:no suitable method found for |incompatible types: cannot infer type-variable\\(s\\)).*");
+
+    /** A cast, as opposed to a parenthesised expression: a type and nothing else. */
+    private static final Pattern TYPE_IN_PARENTHESES =
+            Pattern.compile("\\s*[\\w.$]+(?:\\s*<.*>)?(?:\\s*\\[\\s*])*\\s*", Pattern.DOTALL);
+
+    @Override
+    public String name() {
+        return "argument-cast";
+    }
+
+    @Override
+    public boolean apply(final CompileDiagnostic diagnostic, final SourceDocument document) {
+        if (!UNRESOLVED_CALL.matcher(diagnostic.summary()).matches() || !diagnostic.hasSpan()) {
+            return false;
+        }
+
+        // The compiler reports the operand of the cast rather than the cast itself, so the cast is
+        // what stands immediately in front of the reported expression.
+        final String text = document.text();
+        final int castEnd = closingParenthesisBefore(text, diagnostic.startPosition());
+        if (castEnd < 0) {
+            return false;
+        }
+
+        final int castStart = matchingOpenParenthesis(text, castEnd);
+        if (castStart < 0
+                || !TYPE_IN_PARENTHESES
+                        .matcher(text)
+                        .region(castStart + 1, castEnd)
+                        .matches()) {
+            return false;
+        }
+
+        document.replace(castStart, castEnd + 1, "");
+        return true;
+    }
+
+    /**
+     * Finds the parenthesis that closes immediately before a position.
+     *
+     * @param text source text
+     * @param start offset of the reported expression
+     * @return offset of that parenthesis, or {@code -1} if something else precedes the expression
+     */
+    private static int closingParenthesisBefore(final String text, final int start) {
+        int index = start - 1;
+        while (index >= 0 && Character.isWhitespace(text.charAt(index))) {
+            index--;
+        }
+        return index >= 0 && text.charAt(index) == ')' ? index : -1;
+    }
+
+    /**
+     * Finds the parenthesis matching a closing one.
+     *
+     * @param text source text
+     * @param closing offset of the closing parenthesis
+     * @return offset of the matching opening parenthesis, or {@code -1} if there is none
+     */
+    private static int matchingOpenParenthesis(final String text, final int closing) {
+        int depth = 0;
+        for (int index = closing; index >= 0; index--) {
+            final char current = text.charAt(index);
+            if (current == ')') {
+                depth++;
+            } else if (current == '(') {
+                depth--;
+                if (depth == 0) {
+                    return index;
+                }
+            } else if (current == ';' || current == '{' || current == '}') {
+                return -1;
+            }
+        }
+        return -1;
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/CatchParameterRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/CatchParameterRepair.java
@@ -1,0 +1,74 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Reunites a catch parameter with the name its body uses.
+ *
+ * <p>When nested handlers carry the same name in the local variable table, the decompiler renames
+ * the declarations to keep them distinct but leaves the references pointing at the original name.
+ * The handler body then reads a variable that no longer exists.
+ *
+ * <p>The body is authoritative here: it is what the original code said, so the declaration is moved
+ * back onto that name rather than the references being rewritten. The repair only applies when the
+ * declared name is genuinely unused in the body, which is what distinguishes this defect from code
+ * that merely references something declared elsewhere.
+ */
+final class CatchParameterRepair implements SourceRepair {
+
+    private static final Pattern MISSING_VARIABLE = Pattern.compile("symbol:\\s*variable (\\w+)");
+
+    /** Matches the parameter of the {@code catch} clause a block belongs to. */
+    private static final Pattern CATCH_CLAUSE =
+            Pattern.compile("catch\\s*\\(\\s*(?:final\\s+)?[\\w.$]+(?:\\s*\\|\\s*[\\w.$]+)*\\s+(\\w+)\\s*\\)\\s*$");
+
+    @Override
+    public String name() {
+        return "catch-parameter";
+    }
+
+    @Override
+    public boolean apply(final CompileDiagnostic diagnostic, final SourceDocument document) {
+        if (!"cannot find symbol".equals(diagnostic.summary())) {
+            return false;
+        }
+
+        final Matcher missing = MISSING_VARIABLE.matcher(diagnostic.message());
+        if (!missing.find()) {
+            return false;
+        }
+
+        final String name = missing.group(1);
+        final int usage = document.offsetOf(diagnostic.line(), diagnostic.column());
+        if (usage < 0) {
+            return false;
+        }
+
+        final String text = document.text();
+        final List<Integer> braces = JavaText.enclosingBraces(text, usage);
+        for (int index = braces.size() - 1; index >= 0; index--) {
+            final int blockStart = braces.get(index);
+            final Matcher clause = CATCH_CLAUSE.matcher(text).region(lineStartBefore(text, blockStart), blockStart);
+            if (!clause.find()) {
+                continue;
+            }
+
+            final int blockEnd = JavaText.matchingBrace(text, blockStart);
+            if (blockEnd < 0 || JavaText.containsIdentifier(text, clause.group(1), blockStart, blockEnd)) {
+                continue;
+            }
+
+            document.replace(clause.start(1), clause.end(1), name);
+            return true;
+        }
+        return false;
+    }
+
+    /** @return the offset of the start of the line containing {@code offset} */
+    private static int lineStartBefore(final String text, final int offset) {
+        final int lineBreak = text.lastIndexOf('\n', offset);
+        return lineBreak < 0 ? 0 : lineBreak + 1;
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/CompileDiagnostic.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/CompileDiagnostic.java
@@ -1,0 +1,47 @@
+package de.timmi6790.sourcerepair;
+
+import java.nio.file.Path;
+
+/**
+ * A single compiler error reported against a decompiled source file.
+ *
+ * <p>Positions are one-based, matching what the compiler reports, and refer to the file contents as
+ * they were when the diagnostic was produced. A repair therefore has to be applied to the same
+ * revision of the file, which the repair loop guarantees by recompiling after every round.
+ *
+ * @param file source file the error was reported against
+ * @param line one-based line of the offending construct
+ * @param column one-based column of the offending construct
+ * @param startPosition offset of the first character of the offending construct, or {@code -1}
+ * @param endPosition offset just past its last character, or {@code -1}
+ * @param message the compiler message, including any detail lines
+ */
+public record CompileDiagnostic(Path file, int line, int column, int startPosition, int endPosition, String message) {
+
+    /**
+     * Whether the compiler reported the full extent of the offending construct.
+     *
+     * <p>The reported line and column point at whichever token reads best in a console message,
+     * which for a call chain is the parenthesis of the last call rather than the start of the
+     * receiver. Only the span identifies the whole expression, so a rewrite that has to replace one
+     * needs this to be true.
+     *
+     * @return {@code true} if {@link #startPosition} and {@link #endPosition} delimit a span
+     */
+    public boolean hasSpan() {
+        return this.startPosition >= 0 && this.endPosition > this.startPosition;
+    }
+
+    /**
+     * The first line of {@link #message}, which carries the error kind.
+     *
+     * <p>Detail lines below it explain an error but never identify it, so rules match on this line
+     * alone and read the details only once they have decided the error is theirs.
+     *
+     * @return the first line of the message
+     */
+    public String summary() {
+        final int lineBreak = this.message.indexOf('\n');
+        return lineBreak < 0 ? this.message : this.message.substring(0, lineBreak);
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/DuplicateVariableRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/DuplicateVariableRepair.java
@@ -1,0 +1,111 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Renames a local the decompiler declared twice in one scope.
+ *
+ * <p>The arms of a {@code switch} statement share a single scope, but each arm was a separate scope
+ * in the bytecode's line table. A decompiler that recovers the original variable names per arm
+ * therefore emits the same name once per arm, which the compiler rejects even though the arms can
+ * never both run.
+ *
+ * <p>Only the rejected declaration and the uses that belong to it are renamed. Renaming stops at the
+ * next {@code case} or {@code default} label, so the arm that legitimately owns the name keeps it.
+ */
+final class DuplicateVariableRepair implements SourceRepair {
+
+    private static final Pattern ALREADY_DEFINED = Pattern.compile("^variable (\\w+) is already defined\\b");
+
+    /** A label starts a new arm, and with it a new set of variables that must not be renamed. */
+    private static final Pattern ARM_LABEL = Pattern.compile("\\b(?:case|default)\\b");
+
+    @Override
+    public String name() {
+        return "duplicate-variable";
+    }
+
+    @Override
+    public boolean apply(final CompileDiagnostic diagnostic, final SourceDocument document) {
+        final Matcher matcher = ALREADY_DEFINED.matcher(diagnostic.summary());
+        if (!matcher.find()) {
+            return false;
+        }
+
+        final String name = matcher.group(1);
+        final int declaration = document.offsetOf(diagnostic.line(), diagnostic.column());
+        if (declaration < 0 || !document.text().startsWith(name, declaration)) {
+            return false;
+        }
+
+        final int scopeEnd = endOfArm(document.text(), declaration);
+        if (scopeEnd < 0) {
+            return false;
+        }
+
+        final String replacement = freshName(document.text(), name);
+        int occurrence = declaration;
+        while (occurrence >= 0) {
+            document.replace(occurrence, occurrence + name.length(), replacement);
+            occurrence = JavaText.indexOfIdentifier(document.text(), name, occurrence + name.length(), scopeEnd);
+        }
+        return true;
+    }
+
+    /**
+     * Finds where the declaration's arm ends.
+     *
+     * @param text source text
+     * @param declaration offset of the redeclared name
+     * @return offset of the next arm label or of the end of the enclosing block, or {@code -1} if
+     *     the declaration is not inside a block
+     */
+    private static int endOfArm(final String text, final int declaration) {
+        final var braces = JavaText.enclosingBraces(text, declaration);
+        if (braces.isEmpty()) {
+            return -1;
+        }
+
+        final int blockEnd = JavaText.matchingBrace(text, braces.get(braces.size() - 1));
+        if (blockEnd < 0) {
+            return -1;
+        }
+
+        final int nextLabel = nextArmLabel(text, declaration, blockEnd);
+        return nextLabel < 0 ? blockEnd : nextLabel;
+    }
+
+    private static int nextArmLabel(final String text, final int from, final int limit) {
+        int depth = 0;
+        for (int index = from; index < limit; index++) {
+            final int skipped = JavaText.skipInert(text, index);
+            if (skipped != index) {
+                index = skipped - 1;
+                continue;
+            }
+
+            final char current = text.charAt(index);
+            if (current == '{') {
+                depth++;
+            } else if (current == '}') {
+                depth--;
+            } else if (depth == 0 && (current == 'c' || current == 'd')) {
+                final Matcher label = ARM_LABEL.matcher(text).region(index, Math.min(index + 8, limit));
+                if (label.lookingAt()) {
+                    return index;
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static String freshName(final String text, final String name) {
+        for (int suffix = 1; ; suffix++) {
+            final String candidate = name + suffix;
+            if (!JavaText.containsIdentifier(text, candidate, 0, text.length())) {
+                return candidate;
+            }
+        }
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/ExternalJavaCompiler.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/ExternalJavaCompiler.java
@@ -1,0 +1,304 @@
+package de.timmi6790.sourcerepair;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Type-checks a source tree using a JDK installed on the machine.
+ *
+ * <p>A native image contains no compiler, and adding one would mean building all of {@code
+ * jdk.compiler} into the binary. Borrowing an installed JDK avoids that and costs nothing at build
+ * time, at the price of requiring one to be present — which is a requirement of the generated
+ * project anyway.
+ *
+ * <p>Rather than parsing console output, a small program is handed to that JDK's source launcher and
+ * run there. It drives the same compiler API and reports the same diagnostics, so both compilers
+ * produce identical results — including the exact source spans, which console output does not carry
+ * and which the repairs depend on.
+ */
+@Slf4j
+final class ExternalJavaCompiler implements JavaSourceCompiler {
+
+    private static final Pattern VERSION = Pattern.compile("(\\d+)");
+
+    private static final String PROBE_NAME = "SourceRepairProbe";
+
+    /** Written to disk and run by the external JDK; see the class javadoc for why. */
+    private static final String PROBE_SOURCE = """
+            import java.io.File;
+            import java.io.OutputStream;
+            import java.io.Writer;
+            import java.net.URI;
+            import java.nio.charset.StandardCharsets;
+            import java.nio.file.Files;
+            import java.nio.file.Path;
+            import java.util.ArrayList;
+            import java.util.List;
+            import java.util.Locale;
+            import javax.tools.Diagnostic;
+            import javax.tools.DiagnosticCollector;
+            import javax.tools.FileObject;
+            import javax.tools.ForwardingJavaFileManager;
+            import javax.tools.JavaCompiler;
+            import javax.tools.JavaFileManager;
+            import javax.tools.JavaFileObject;
+            import javax.tools.SimpleJavaFileObject;
+            import javax.tools.StandardJavaFileManager;
+            import javax.tools.ToolProvider;
+
+            public final class SourceRepairProbe {
+
+                public static void main(final String[] args) throws Exception {
+                    final List<String> options = new ArrayList<>();
+                    final List<File> sources = new ArrayList<>();
+                    for (final String line : Files.readAllLines(Path.of(args[0]), StandardCharsets.UTF_8)) {
+                        if (line.startsWith("O:")) {
+                            options.add(line.substring(2));
+                        } else if (line.startsWith("S:")) {
+                            sources.add(new File(line.substring(2)));
+                        }
+                    }
+
+                    final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+                    final DiagnosticCollector<JavaFileObject> collector = new DiagnosticCollector<>();
+                    try (StandardJavaFileManager files =
+                            compiler.getStandardFileManager(collector, Locale.ROOT, StandardCharsets.UTF_8)) {
+                        final JavaFileManager discarding = new ForwardingJavaFileManager<StandardJavaFileManager>(files) {
+                            @Override
+                            public JavaFileObject getJavaFileForOutput(
+                                    final Location location,
+                                    final String className,
+                                    final JavaFileObject.Kind kind,
+                                    final FileObject sibling) {
+                                final URI uri = URI.create("discard:///" + className.replace('.', '/') + kind.extension);
+                                return new SimpleJavaFileObject(uri, kind) {
+                                    @Override
+                                    public OutputStream openOutputStream() {
+                                        return OutputStream.nullOutputStream();
+                                    }
+                                };
+                            }
+                        };
+                        compiler.getTask(
+                                        Writer.nullWriter(),
+                                        discarding,
+                                        collector,
+                                        options,
+                                        null,
+                                        files.getJavaFileObjectsFromFiles(sources))
+                                .call();
+                    }
+
+                    final StringBuilder report = new StringBuilder();
+                    for (final Diagnostic<? extends JavaFileObject> diagnostic : collector.getDiagnostics()) {
+                        if (diagnostic.getKind() != Diagnostic.Kind.ERROR || diagnostic.getSource() == null) {
+                            continue;
+                        }
+                        report.append(diagnostic.getLineNumber())
+                                .append('\\t')
+                                .append(diagnostic.getColumnNumber())
+                                .append('\\t')
+                                .append(diagnostic.getStartPosition())
+                                .append('\\t')
+                                .append(diagnostic.getEndPosition())
+                                .append('\\t')
+                                .append(Path.of(diagnostic.getSource().toUri()))
+                                .append('\\t')
+                                .append(diagnostic
+                                        .getMessage(Locale.ROOT)
+                                        .replace("\\\\", "\\\\\\\\")
+                                        .replace("\\r", "")
+                                        .replace("\\n", "\\\\n"))
+                                .append('\\n');
+                    }
+                    Files.writeString(Path.of(args[1]), report.toString(), StandardCharsets.UTF_8);
+                }
+            }
+            """;
+
+    private final Path javaExecutable;
+    private final Path workingDirectory;
+    private final int release;
+
+    private ExternalJavaCompiler(final Path javaExecutable, final Path workingDirectory, final int release) {
+        this.javaExecutable = javaExecutable;
+        this.workingDirectory = workingDirectory;
+        this.release = release;
+    }
+
+    /**
+     * Finds an installed JDK new enough to build the given source level.
+     *
+     * @param release the Java release the sources target
+     * @return the compiler, or {@code null} if no suitable JDK was found
+     */
+    static ExternalJavaCompiler create(final int release) {
+        for (final Path home : candidateJdkHomes()) {
+            final Path java = executable(home, "java");
+            final Path javac = executable(home, "javac");
+            if (!Files.isRegularFile(java) || !Files.isRegularFile(javac)) {
+                continue;
+            }
+
+            final int feature = featureVersionOf(javac);
+            if (feature < release) {
+                log.debug("Skipping JDK {}: Java {} cannot build Java {} sources", home, feature, release);
+                continue;
+            }
+
+            try {
+                final Path workingDirectory = Files.createTempDirectory("mcdeob-source-repair");
+                Files.writeString(workingDirectory.resolve(PROBE_NAME + ".java"), PROBE_SOURCE, StandardCharsets.UTF_8);
+                log.info("Using the JDK at {} to type-check the sources", home);
+                return new ExternalJavaCompiler(java, workingDirectory, release);
+            } catch (final IOException exception) {
+                log.warn("Could not prepare the external compiler", exception);
+                return null;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<CompileDiagnostic> compile(final List<Path> sources, final List<Path> classpath) throws IOException {
+        final Path request = this.workingDirectory.resolve("request.txt");
+        final Path response = this.workingDirectory.resolve("response.txt");
+
+        final List<String> lines = new ArrayList<>(sources.size() + 16);
+        for (final String option : JavaSourceCompiler.optionsFor(this.release, classpath)) {
+            lines.add("O:" + option);
+        }
+        for (final Path source : sources) {
+            lines.add("S:" + source.toAbsolutePath());
+        }
+        Files.write(request, lines, StandardCharsets.UTF_8);
+        Files.deleteIfExists(response);
+
+        final Process process = new ProcessBuilder(
+                        this.javaExecutable.toString(),
+                        this.workingDirectory.resolve(PROBE_NAME + ".java").toString(),
+                        request.toString(),
+                        response.toString())
+                .directory(this.workingDirectory.toFile())
+                .redirectErrorStream(true)
+                .redirectOutput(this.workingDirectory.resolve("probe.log").toFile())
+                .start();
+
+        try {
+            if (process.waitFor() != 0 || !Files.exists(response)) {
+                throw new IOException("External compiler failed; see "
+                        + this.workingDirectory.resolve("probe.log").toAbsolutePath());
+            }
+        } catch (final InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while type-checking", exception);
+        }
+
+        return parse(Files.readAllLines(response, StandardCharsets.UTF_8));
+    }
+
+    private static List<CompileDiagnostic> parse(final List<String> lines) {
+        final List<CompileDiagnostic> diagnostics = new ArrayList<>(lines.size());
+        for (final String line : lines) {
+            final String[] fields = line.split("\t", 6);
+            if (fields.length < 6) {
+                continue;
+            }
+
+            diagnostics.add(new CompileDiagnostic(
+                    Path.of(fields[4]),
+                    Integer.parseInt(fields[0]),
+                    Integer.parseInt(fields[1]),
+                    Integer.parseInt(fields[2]),
+                    Integer.parseInt(fields[3]),
+                    fields[5].replace("\\n", "\n").replace("\\\\", "\\")));
+        }
+        return diagnostics;
+    }
+
+    /**
+     * Places a JDK might be installed, most specific first.
+     *
+     * <p>The Gradle toolchain directory is included last because a generated project downloads its
+     * toolchain there, so a machine that has built one of these projects already has a matching JDK
+     * even if nothing else on it does.
+     *
+     * @return directories that may be JDK homes
+     */
+    private static List<Path> candidateJdkHomes() {
+        final List<Path> homes = new ArrayList<>();
+        addIfPresent(homes, System.getenv("JAVA_HOME"));
+        addIfPresent(homes, System.getProperty("java.home"));
+
+        final String path = System.getenv("PATH");
+        if (path != null) {
+            for (final String entry : path.split(Pattern.quote(java.io.File.pathSeparator))) {
+                if (!entry.isBlank()) {
+                    // PATH lists bin directories; the home is their parent.
+                    addIfPresent(homes, Path.of(entry).getParent());
+                }
+            }
+        }
+
+        final Path gradleToolchains = Path.of(System.getProperty("user.home", "."), ".gradle", "jdks");
+        if (Files.isDirectory(gradleToolchains)) {
+            try (var entries = Files.list(gradleToolchains)) {
+                entries.filter(Files::isDirectory).forEach(homes::add);
+            } catch (final IOException | UncheckedIOException exception) {
+                log.debug("Could not list Gradle toolchains", exception);
+            }
+        }
+        return homes;
+    }
+
+    private static void addIfPresent(final List<Path> homes, final String candidate) {
+        if (candidate != null && !candidate.isBlank()) {
+            homes.add(Path.of(candidate));
+        }
+    }
+
+    private static void addIfPresent(final List<Path> homes, final Path candidate) {
+        if (candidate != null) {
+            homes.add(candidate);
+        }
+    }
+
+    private static Path executable(final Path home, final String name) {
+        final boolean windows =
+                System.getProperty("os.name", "").toLowerCase(Locale.ENGLISH).contains("win");
+        return home.resolve("bin").resolve(windows ? name + ".exe" : name);
+    }
+
+    /**
+     * Reads a compiler's feature version.
+     *
+     * @param javac the compiler executable
+     * @return the feature version, or {@code -1} if it could not be determined
+     */
+    private static int featureVersionOf(final Path javac) {
+        try {
+            final Process process = new ProcessBuilder(javac.toString(), "-version")
+                    .redirectErrorStream(true)
+                    .start();
+            final String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            process.waitFor();
+
+            final Matcher version = VERSION.matcher(output);
+            return version.find() ? Integer.parseInt(version.group(1)) : -1;
+        } catch (final IOException exception) {
+            return -1;
+        } catch (final InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return -1;
+        }
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/FunctionalInterfaceRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/FunctionalInterfaceRepair.java
@@ -1,0 +1,97 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Restores the cast that gave a lambda a functional target type.
+ *
+ * <p>A lambda assigned to an interface that has more than one abstract method was written with a
+ * cast to a single-method subtype of it. The cast is erased at compile time — the call site records
+ * the subtype in its bootstrap arguments, not in the bytecode of the assignment — so a decompiler
+ * that reproduces the field's declared type alone drops it, and the lambda is left with no target.
+ *
+ * <p>The subtype is recovered from the interface's own source. If it declares more than one
+ * single-method subtype the repair declines: the choice would decide which behaviour the lambda gets
+ * and the diagnostic says nothing about which was meant, so guessing could produce code that
+ * compiles and is wrong.
+ */
+final class FunctionalInterfaceRepair implements SourceRepair {
+
+    private static final Pattern NOT_FUNCTIONAL =
+            Pattern.compile("^incompatible types: (\\S+) is not a functional interface$");
+
+    private static final String FUNCTIONAL_ANNOTATION = "@FunctionalInterface";
+
+    private final SourceTree sourceTree;
+
+    FunctionalInterfaceRepair(final SourceTree sourceTree) {
+        this.sourceTree = sourceTree;
+    }
+
+    @Override
+    public String name() {
+        return "functional-interface";
+    }
+
+    @Override
+    public boolean apply(final CompileDiagnostic diagnostic, final SourceDocument document) {
+        final Matcher matcher = NOT_FUNCTIONAL.matcher(diagnostic.summary());
+        if (!matcher.matches() || !diagnostic.hasSpan()) {
+            return false;
+        }
+
+        final String interfaceName = matcher.group(1);
+        final Optional<String> declaration = this.sourceTree.read(interfaceName);
+        if (declaration.isEmpty()) {
+            return false;
+        }
+
+        final List<String> candidates = functionalSubtypesOf(declaration.get(), simpleNameOf(interfaceName));
+        if (candidates.size() != 1) {
+            return false;
+        }
+
+        final int start = diagnostic.startPosition();
+        final int end = Math.min(diagnostic.endPosition(), document.text().length());
+        if (end <= start) {
+            return false;
+        }
+
+        final String target = interfaceName + "." + candidates.get(0);
+        final String expression = document.text().substring(start, end);
+        if (expression.startsWith("(" + target + ")")) {
+            return false;
+        }
+
+        document.replace(start, end, "(" + target + ")(" + expression + ")");
+        return true;
+    }
+
+    /**
+     * Finds the single-method interfaces an interface declares for use as lambda targets.
+     *
+     * @param declaration source of the interface
+     * @param simpleName its simple name, which its own subtypes extend
+     * @return names of the nested interfaces that extend it and are marked functional
+     */
+    private static List<String> functionalSubtypesOf(final String declaration, final String simpleName) {
+        final Pattern subtype = Pattern.compile(Pattern.quote(FUNCTIONAL_ANNOTATION)
+                + "\\s+(?:\\w+\\s+)*interface\\s+(\\w+)[^{]*\\bextends\\b[^{]*\\b" + Pattern.quote(simpleName) + "\\b");
+
+        final List<String> candidates = new ArrayList<>();
+        final Matcher matcher = subtype.matcher(declaration);
+        while (matcher.find()) {
+            candidates.add(matcher.group(1));
+        }
+        return candidates;
+    }
+
+    private static String simpleNameOf(final String qualifiedName) {
+        final int lastSegment = qualifiedName.lastIndexOf('.');
+        return lastSegment < 0 ? qualifiedName : qualifiedName.substring(lastSegment + 1);
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/InProcessJavaCompiler.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/InProcessJavaCompiler.java
@@ -1,0 +1,132 @@
+package de.timmi6790.sourcerepair;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import javax.tools.DiagnosticCollector;
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Type-checks a source tree using the compiler of the runtime McDeob is running on.
+ *
+ * <p>Generated class files are discarded: the repair loop only ever needs the errors, and writing
+ * several thousand class files per round would dominate its runtime.
+ */
+@Slf4j
+final class InProcessJavaCompiler implements JavaSourceCompiler {
+
+    private final JavaCompiler compiler;
+    private final int release;
+
+    private InProcessJavaCompiler(final JavaCompiler compiler, final int release) {
+        this.compiler = compiler;
+        this.release = release;
+    }
+
+    /**
+     * Creates a compiler backed by the running runtime.
+     *
+     * @param release the Java release the sources target
+     * @return the compiler, or {@code null} if this runtime cannot compile that release
+     */
+    static InProcessJavaCompiler create(final int release) {
+        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            log.debug("This runtime ships no Java compiler; an external one is needed instead");
+            return null;
+        }
+
+        final int runtimeFeature = Runtime.version().feature();
+        if (runtimeFeature < release) {
+            log.debug("Sources target Java {} but this runtime is Java {}", release, runtimeFeature);
+            return null;
+        }
+
+        return new InProcessJavaCompiler(compiler, release);
+    }
+
+    @Override
+    public List<CompileDiagnostic> compile(final List<Path> sources, final List<Path> classpath) throws IOException {
+        final DiagnosticCollector<JavaFileObject> collector = new DiagnosticCollector<>();
+
+        try (StandardJavaFileManager standardFileManager =
+                        this.compiler.getStandardFileManager(collector, Locale.ROOT, StandardCharsets.UTF_8);
+                JavaFileManager fileManager = new DiscardingFileManager(standardFileManager)) {
+
+            final List<String> options = JavaSourceCompiler.optionsFor(this.release, classpath);
+
+            final Iterable<? extends JavaFileObject> units = standardFileManager.getJavaFileObjectsFromPaths(sources);
+            this.compiler
+                    .getTask(Writer.nullWriter(), fileManager, collector, options, null, units)
+                    .call();
+        }
+
+        return toDiagnostics(collector);
+    }
+
+    private static List<CompileDiagnostic> toDiagnostics(final DiagnosticCollector<JavaFileObject> collector) {
+        final List<CompileDiagnostic> diagnostics = new ArrayList<>();
+        for (final javax.tools.Diagnostic<? extends JavaFileObject> diagnostic : collector.getDiagnostics()) {
+            if (diagnostic.getKind() != javax.tools.Diagnostic.Kind.ERROR) {
+                continue;
+            }
+
+            final JavaFileObject source = diagnostic.getSource();
+            if (source == null) {
+                continue;
+            }
+
+            diagnostics.add(new CompileDiagnostic(
+                    Path.of(source.toUri()),
+                    (int) diagnostic.getLineNumber(),
+                    (int) diagnostic.getColumnNumber(),
+                    (int) diagnostic.getStartPosition(),
+                    (int) diagnostic.getEndPosition(),
+                    diagnostic.getMessage(Locale.ROOT)));
+        }
+        return diagnostics;
+    }
+
+    /** Sends generated class files nowhere; only diagnostics are of interest. */
+    private static final class DiscardingFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
+
+        private DiscardingFileManager(final StandardJavaFileManager fileManager) {
+            super(fileManager);
+        }
+
+        @Override
+        public JavaFileObject getJavaFileForOutput(
+                final Location location,
+                final String className,
+                final JavaFileObject.Kind kind,
+                final FileObject sibling) {
+            return new DiscardingFileObject(className, kind);
+        }
+    }
+
+    private static final class DiscardingFileObject extends SimpleJavaFileObject {
+
+        private DiscardingFileObject(final String className, final Kind kind) {
+            super(URI.create("discard:///" + className.replace('.', '/') + kind.extension), kind);
+        }
+
+        @Override
+        public OutputStream openOutputStream() {
+            return OutputStream.nullOutputStream();
+        }
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/JavaSourceCompiler.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/JavaSourceCompiler.java
@@ -1,0 +1,92 @@
+package de.timmi6790.sourcerepair;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Type-checks a source tree and reports what the compiler rejects.
+ *
+ * <p>Which compiler does the work depends on how McDeob was started. Running on a JDK, the one built
+ * into the runtime is used directly. A native image has no compiler of its own, so a JDK installed
+ * on the machine is borrowed instead — otherwise the feature would be unavailable in exactly the
+ * distribution most users run.
+ */
+interface JavaSourceCompiler {
+
+    Logger LOG = LoggerFactory.getLogger(JavaSourceCompiler.class);
+
+    /** Effectively unlimited; the loop needs every error of a round, not the first hundred. */
+    String MAX_ERRORS = "100000";
+
+    /**
+     * Compiles a source tree and collects the errors.
+     *
+     * @param sources the source files to compile
+     * @param classpath jars the sources compile against
+     * @return every error reported, in the order the compiler produced them
+     * @throws IOException if the compiler cannot be run
+     */
+    List<CompileDiagnostic> compile(List<Path> sources, List<Path> classpath) throws IOException;
+
+    /**
+     * Finds a compiler able to build the given source level.
+     *
+     * @param release the Java release the sources target
+     * @return a compiler, or {@code null} if the machine offers none new enough
+     */
+    static JavaSourceCompiler create(final int release) {
+        final InProcessJavaCompiler inProcess = InProcessJavaCompiler.create(release);
+        if (inProcess != null) {
+            return inProcess;
+        }
+
+        final ExternalJavaCompiler external = ExternalJavaCompiler.create(release);
+        if (external != null) {
+            return external;
+        }
+
+        LOG.warn(
+                "No Java {} compiler found, so the sources cannot be type-checked and are left unrepaired."
+                        + " Install a JDK {} or newer, or point JAVA_HOME at one, to enable source repair.",
+                release,
+                release);
+        return null;
+    }
+
+    /**
+     * The compiler options a repair round runs with, identical whichever compiler is used.
+     *
+     * @param release the Java release the sources target
+     * @param classpath jars the sources compile against
+     * @return the options, ready to pass to the compiler
+     */
+    static List<String> optionsFor(final int release, final List<Path> classpath) {
+        final List<String> options = new ArrayList<>(List.of(
+                "--release",
+                Integer.toString(release),
+                "-encoding",
+                StandardCharsets.UTF_8.name(),
+                "-proc:none",
+                "-nowarn",
+                "-Xmaxerrs",
+                MAX_ERRORS));
+
+        if (!classpath.isEmpty()) {
+            final StringBuilder joined = new StringBuilder();
+            for (final Path entry : classpath) {
+                if (!joined.isEmpty()) {
+                    joined.append(java.io.File.pathSeparatorChar);
+                }
+                joined.append(entry.toAbsolutePath());
+            }
+            options.add("-classpath");
+            options.add(joined.toString());
+        }
+        return options;
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/JavaText.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/JavaText.java
@@ -1,0 +1,228 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Text-level navigation over Java source.
+ *
+ * <p>The repair rules need to find where an expression ends or which block a position sits in, but
+ * not what any of it means. Scanning the text is enough for that and keeps the repair stage free of
+ * a parser dependency; the compiler remains the only component that has to understand the code.
+ *
+ * <p>Every scan skips comments and literals, so a brace inside a string can never be mistaken for
+ * structure.
+ */
+final class JavaText {
+
+    /** Header of an enhanced {@code for}, matched against the text preceding its parenthesis. */
+    private static final Pattern FOR_HEADER = Pattern.compile("\\bfor\\s*$");
+
+    private JavaText() {}
+
+    /**
+     * Advances past a comment or literal starting at {@code index}.
+     *
+     * @param text source text
+     * @param index offset to inspect
+     * @return the offset just past the comment or literal, or {@code index} if none starts there
+     */
+    static int skipInert(final String text, final int index) {
+        final char current = text.charAt(index);
+        if (current == '/' && index + 1 < text.length()) {
+            final char next = text.charAt(index + 1);
+            if (next == '/') {
+                final int lineBreak = text.indexOf('\n', index + 2);
+                return lineBreak < 0 ? text.length() : lineBreak;
+            }
+            if (next == '*') {
+                final int end = text.indexOf("*/", index + 2);
+                return end < 0 ? text.length() : end + 2;
+            }
+            return index;
+        }
+
+        if (current == '"' && text.startsWith("\"\"\"", index)) {
+            return endOfDelimited(text, index + 3, "\"\"\"");
+        }
+        if (current == '"') {
+            return endOfDelimited(text, index + 1, "\"");
+        }
+        if (current == '\'') {
+            return endOfDelimited(text, index + 1, "'");
+        }
+        return index;
+    }
+
+    private static int endOfDelimited(final String text, final int start, final String terminator) {
+        for (int index = start; index < text.length(); index++) {
+            final char current = text.charAt(index);
+            if (current == '\\') {
+                index++;
+                continue;
+            }
+            if (text.startsWith(terminator, index)) {
+                return index + terminator.length();
+            }
+        }
+        return text.length();
+    }
+
+    /**
+     * Collects the offsets of the braces enclosing a position, outermost first.
+     *
+     * @param text source text
+     * @param offset position to locate
+     * @return offsets of the opening braces that are still unclosed at {@code offset}
+     */
+    static List<Integer> enclosingBraces(final String text, final int offset) {
+        final List<Integer> open = new ArrayList<>();
+        for (int index = 0; index < offset && index < text.length(); index++) {
+            final int skipped = skipInert(text, index);
+            if (skipped != index) {
+                index = skipped - 1;
+                continue;
+            }
+
+            final char current = text.charAt(index);
+            if (current == '{') {
+                open.add(index);
+            } else if (current == '}' && !open.isEmpty()) {
+                open.remove(open.size() - 1);
+            }
+        }
+        return open;
+    }
+
+    /**
+     * Checks whether an expression is the sequence of an enhanced {@code for}.
+     *
+     * <p>An error reported there is about the element type, not about the sequence, so a repair has
+     * to act on what the sequence yields rather than on the sequence itself.
+     *
+     * @param text source text
+     * @param start offset of the first character of the expression
+     * @return {@code true} if the expression follows the colon of an enhanced {@code for}
+     */
+    static boolean isEnhancedForSequence(final String text, final int start) {
+        int index = start - 1;
+        while (index >= 0 && Character.isWhitespace(text.charAt(index))) {
+            index--;
+        }
+        if (index < 0 || text.charAt(index) != ':') {
+            return false;
+        }
+
+        final List<Integer> parentheses = enclosingParentheses(text, start);
+        if (parentheses.isEmpty()) {
+            return false;
+        }
+
+        final int open = parentheses.get(parentheses.size() - 1);
+        return FOR_HEADER.matcher(text).region(Math.max(0, open - 8), open).find();
+    }
+
+    /**
+     * Collects the offsets of the parentheses enclosing a position, outermost first.
+     *
+     * @param text source text
+     * @param offset position to locate
+     * @return offsets of the opening parentheses that are still unclosed at {@code offset}
+     */
+    static List<Integer> enclosingParentheses(final String text, final int offset) {
+        final List<Integer> open = new ArrayList<>();
+        for (int index = 0; index < offset && index < text.length(); index++) {
+            final int skipped = skipInert(text, index);
+            if (skipped != index) {
+                index = skipped - 1;
+                continue;
+            }
+
+            final char current = text.charAt(index);
+            if (current == '(') {
+                open.add(index);
+            } else if (current == ')' && !open.isEmpty()) {
+                open.remove(open.size() - 1);
+            }
+        }
+        return open;
+    }
+
+    /**
+     * Finds the closing brace matching an opening one.
+     *
+     * @param text source text
+     * @param openBrace offset of the opening brace
+     * @return offset of the matching closing brace, or {@code -1} if the source is unbalanced
+     */
+    static int matchingBrace(final String text, final int openBrace) {
+        int depth = 0;
+        for (int index = openBrace; index < text.length(); index++) {
+            final int skipped = skipInert(text, index);
+            if (skipped != index) {
+                index = skipped - 1;
+                continue;
+            }
+
+            final char current = text.charAt(index);
+            if (current == '{') {
+                depth++;
+            } else if (current == '}') {
+                depth--;
+                if (depth == 0) {
+                    return index;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Checks whether an identifier occurs as a whole word in a span.
+     *
+     * @param text source text
+     * @param identifier identifier to look for
+     * @param start offset to start searching at
+     * @param end offset to stop searching at
+     * @return {@code true} if the identifier occurs, not as part of a longer name
+     */
+    static boolean containsIdentifier(final String text, final String identifier, final int start, final int end) {
+        return indexOfIdentifier(text, identifier, start, end) >= 0;
+    }
+
+    /**
+     * Finds the first whole-word occurrence of an identifier in a span.
+     *
+     * @param text source text
+     * @param identifier identifier to look for
+     * @param start offset to start searching at
+     * @param end offset to stop searching at
+     * @return the offset of the occurrence, or {@code -1} if there is none
+     */
+    static int indexOfIdentifier(final String text, final String identifier, final int start, final int end) {
+        final int limit = Math.min(end, text.length());
+        for (int index = Math.max(start, 0); index < limit; index++) {
+            final int skipped = skipInert(text, index);
+            if (skipped != index) {
+                index = skipped - 1;
+                continue;
+            }
+            if (!text.startsWith(identifier, index)) {
+                continue;
+            }
+            if (isIdentifierPart(text, index - 1) || isIdentifierPart(text, index + identifier.length())) {
+                continue;
+            }
+            if (index + identifier.length() > limit) {
+                return -1;
+            }
+            return index;
+        }
+        return -1;
+    }
+
+    private static boolean isIdentifierPart(final String text, final int index) {
+        return index >= 0 && index < text.length() && Character.isJavaIdentifierPart(text.charAt(index));
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/MissingCastRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/MissingCastRepair.java
@@ -1,0 +1,224 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Restores a cast the decompiler dropped.
+ *
+ * <p>Generic casts leave no trace in the bytecode: {@code (Brain<Hoglin>) super.getBrain()} and
+ * {@code super.getBrain()} compile to the same instructions. A decompiler that does not run full
+ * type inference therefore emits the expression without its cast, and the result no longer compiles
+ * even though it describes the original program exactly.
+ *
+ * <p>The compiler names the type the expression has to have, which is precisely the cast that was
+ * lost, so the repair is a recovery rather than a guess. Where the resulting cast is itself illegal
+ * — converting between two parameterisations of the same type, say — the next round reports the
+ * cast expression instead, and it is widened through {@code Object} the way source code would have
+ * to do it by hand.
+ */
+final class MissingCastRepair implements SourceRepair {
+
+    private static final Pattern CONVERSION =
+            Pattern.compile("^(.+?) cannot be converted to (.+?)$", Pattern.MULTILINE);
+
+    /**
+     * Errors whose reported span is the value that has the wrong type, with the conversion spelled
+     * out on a detail line below.
+     *
+     * <p>Every other error that mentions a conversion — an argument mismatch during type inference,
+     * say — reports the span of the enclosing call instead, where a cast would apply to the wrong
+     * expression entirely.
+     */
+    private static final Set<String> DETAILED_SUMMARIES = Set.of(
+            "incompatible types: bad type in conditional expression",
+            "incompatible types: bad return type in lambda expression");
+
+    /**
+     * Type text the compiler prints but source code cannot name: captured wildcards, disambiguated
+     * type variables, intersection types, and messages elided for length.
+     */
+    private static final Pattern INEXPRESSIBLE =
+            Pattern.compile("CAP#|capture#|#\\d|\\[\\.\\.\\.]|&|\\.\\.\\.|<any>|<>");
+
+    /** Splits a type into the names it is built from, discarding punctuation and wildcards. */
+    private static final Pattern TYPE_NAME_SEPARATOR = Pattern.compile("[<>,\\[\\]?\\s]+|\\bextends\\b|\\bsuper\\b");
+
+    /** A parenthesised type, as opposed to a parenthesised expression. */
+    private static final Pattern TYPE_IN_PARENTHESES =
+            Pattern.compile("\\s*[\\w.$]+(?:\\s*<.*>)?(?:\\s*\\[\\s*])*\\s*", Pattern.DOTALL);
+
+    /** The widening this repair inserts; recognised so it is never inserted twice. */
+    private static final String ERASURE_BRIDGE = "(Object)";
+
+    /** Opening of the cast applied to the sequence of an enhanced {@code for}. */
+    private static final String SEQUENCE_CAST = "(Iterable<";
+
+    @Override
+    public String name() {
+        return "missing-cast";
+    }
+
+    @Override
+    public boolean apply(final CompileDiagnostic diagnostic, final SourceDocument document) {
+        final String summary = diagnostic.summary();
+        if (!summary.startsWith("incompatible types:")) {
+            return false;
+        }
+
+        final Matcher conversion =
+                CONVERSION.matcher(DETAILED_SUMMARIES.contains(summary) ? diagnostic.message() : summary);
+        if (!conversion.find()) {
+            return false;
+        }
+
+        final String targetType = balanced(conversion.group(2).trim());
+        final String sourceType = conversion.group(1).trim();
+        if (targetType.equals(sourceType) || !isExpressible(targetType, document.text())) {
+            return false;
+        }
+        if (!diagnostic.hasSpan()) {
+            return false;
+        }
+
+        final int start = diagnostic.startPosition();
+        final int end = Math.min(diagnostic.endPosition(), document.text().length());
+        if (end <= start) {
+            return false;
+        }
+
+        final String expression = document.text().substring(start, end);
+        if (isAlreadyCastTo(document.text(), start, targetType)) {
+            // An earlier round put this very cast in front of the expression and the compiler still
+            // rejects it. Repeating it would stack casts without ever changing the outcome.
+            return false;
+        }
+
+        if (JavaText.isEnhancedForSequence(document.text(), start)) {
+            // The type named here is what the loop variable needs, so the sequence has to be cast to
+            // something that yields it rather than to the element type itself.
+            if (expression.startsWith(SEQUENCE_CAST)) {
+                return false;
+            }
+            document.replace(start, end, SEQUENCE_CAST + targetType + ">)(" + expression + ")");
+            return true;
+        }
+
+        final int operand = castOperandOffset(expression);
+        if (operand > 0) {
+            // A cast is already there and the compiler still rejects it, so the two types are not
+            // directly convertible. Erasing to Object in between is how the same conversion is
+            // written by hand, and is exactly as safe: both are unchecked.
+            if (expression.startsWith(ERASURE_BRIDGE, operand)) {
+                return false;
+            }
+            document.insert(start + operand, ERASURE_BRIDGE);
+            return true;
+        }
+
+        document.replace(start, end, "(" + targetType + ")(" + expression + ")");
+        return true;
+    }
+
+    /**
+     * Checks whether the expression is already preceded by the cast about to be applied.
+     *
+     * <p>Guards against stacking a cast that has already failed once, whether it came from a previous
+     * round or from the decompiler.
+     *
+     * @param text source text
+     * @param start offset of the expression
+     * @param targetType the type the cast would name
+     * @return {@code true} if that cast already stands in front of the expression
+     */
+    private static boolean isAlreadyCastTo(final String text, final int start, final String targetType) {
+        int end = start;
+        while (end > 0 && Character.isWhitespace(text.charAt(end - 1))) {
+            end--;
+        }
+
+        final String cast = "(" + targetType + ")";
+        return end >= cast.length() && text.startsWith(cast, end - cast.length());
+    }
+
+    /**
+     * Drops the trailing parentheses a detail line's own punctuation contributes.
+     *
+     * <p>A detail line reads {@code (argument mismatch; X cannot be converted to Y)}, so the type at
+     * the end of it carries a closing parenthesis that is not part of the type.
+     *
+     * @param type the type as captured from the message
+     * @return the type with unmatched trailing parentheses removed
+     */
+    private static String balanced(final String type) {
+        String result = type;
+        while (result.endsWith(")") && count(result, ')') > count(result, '(')) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+
+    private static int count(final String text, final char character) {
+        int total = 0;
+        for (int index = 0; index < text.length(); index++) {
+            if (text.charAt(index) == character) {
+                total++;
+            }
+        }
+        return total;
+    }
+
+    /**
+     * Locates the operand of a cast expression.
+     *
+     * @param expression the rejected expression
+     * @return the offset of the operand, or {@code -1} if the expression is not a cast
+     */
+    private static int castOperandOffset(final String expression) {
+        if (expression.isEmpty() || expression.charAt(0) != '(') {
+            return -1;
+        }
+
+        int depth = 0;
+        for (int index = 0; index < expression.length(); index++) {
+            final char current = expression.charAt(index);
+            if (current == '(') {
+                depth++;
+            } else if (current == ')' && --depth == 0) {
+                final boolean isType =
+                        TYPE_IN_PARENTHESES.matcher(expression).region(1, index).matches();
+                return isType && index + 1 < expression.length() ? index + 1 : -1;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Checks whether a type the compiler printed can be written in this file.
+     *
+     * <p>Diagnostics name classes in full, so those always resolve. Type variables are printed bare
+     * and only resolve where they are in scope, which requiring them to occur in the file
+     * approximates. The check errs towards declining, so an unrepaired diagnostic is reported
+     * instead of an unresolvable cast being introduced.
+     *
+     * @param type the type as printed by the compiler
+     * @param source the file the cast would be inserted into
+     * @return {@code true} if the type is safe to write into this file
+     */
+    private static boolean isExpressible(final String type, final String source) {
+        if (type.isEmpty() || INEXPRESSIBLE.matcher(type).find()) {
+            return false;
+        }
+
+        for (final String name : TYPE_NAME_SEPARATOR.split(type)) {
+            if (name.isEmpty() || name.indexOf('.') >= 0) {
+                continue;
+            }
+            if (!JavaText.containsIdentifier(source, name, 0, source.length())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/RawConstructorRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/RawConstructorRepair.java
@@ -1,0 +1,103 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Gives a raw constructor call back its diamond.
+ *
+ * <p>A decompiler writes {@code new AnimalPanic(2.5F)} for what the source wrote as {@code new
+ * AnimalPanic<>(2.5F)}, because erasure leaves no record of the diamond. The raw type that results
+ * is not merely untidy: a raw argument erases the whole call it appears in, so the enclosing call
+ * stops resolving too.
+ *
+ * <p>The diamond is only added where the type really does declare type parameters, which is read
+ * from its own source. Only calls the compiler has already rejected are touched.
+ */
+final class RawConstructorRepair implements SourceRepair {
+
+    /** Errors that mean a call could not be resolved against its arguments. */
+    private static final Pattern UNRESOLVED_CALL = Pattern.compile(
+            "^(?:no suitable method found for |incompatible types: cannot infer type-variable\\(s\\)).*");
+
+    /** A constructor call with neither type arguments nor a diamond. */
+    private static final Pattern RAW_CONSTRUCTOR = Pattern.compile("\\bnew\\s+([\\w.$]+)\\s*\\(");
+
+    private final SourceTree sourceTree;
+
+    RawConstructorRepair(final SourceTree sourceTree) {
+        this.sourceTree = sourceTree;
+    }
+
+    @Override
+    public String name() {
+        return "raw-constructor";
+    }
+
+    @Override
+    public boolean apply(final CompileDiagnostic diagnostic, final SourceDocument document) {
+        if (!UNRESOLVED_CALL.matcher(diagnostic.summary()).matches() || !diagnostic.hasSpan()) {
+            return false;
+        }
+
+        final String text = document.text();
+        final int start = Math.max(diagnostic.startPosition(), 0);
+        final int end = Math.min(diagnostic.endPosition(), text.length());
+        if (end <= start) {
+            return false;
+        }
+
+        final Matcher constructor = RAW_CONSTRUCTOR.matcher(text).region(start, end);
+        boolean added = false;
+        while (constructor.find()) {
+            if (this.isGeneric(constructor.group(1), document)) {
+                document.insert(constructor.end() - 1, "<>");
+                added = true;
+            }
+        }
+        return added;
+    }
+
+    /**
+     * Checks whether a type declares type parameters, and so can take a diamond.
+     *
+     * @param typeName the type as written at the constructor call
+     * @param document the file the call appears in
+     * @return {@code true} if the type is generic
+     */
+    private boolean isGeneric(final String typeName, final SourceDocument document) {
+        final String simpleName = typeName.substring(typeName.lastIndexOf('.') + 1);
+        final Pattern declaration =
+                Pattern.compile("\\b(?:class|interface|record)\\s+" + Pattern.quote(simpleName) + "\\s*<");
+
+        // The type is most often declared in the file that uses it or in one named after it; both
+        // are cheap to check and a miss only means the repair declines.
+        if (declaration.matcher(document.text()).find()) {
+            return true;
+        }
+
+        final Optional<String> source = this.sourceTree.read(qualifiedNameIn(document.text(), simpleName));
+        return source.isPresent() && declaration.matcher(source.get()).find();
+    }
+
+    /**
+     * Works out where a simple name comes from, using the file's imports.
+     *
+     * @param text the file referring to the type
+     * @param simpleName the type's simple name
+     * @return the qualified name, or the simple name if no import covers it
+     */
+    private static String qualifiedNameIn(final String text, final String simpleName) {
+        final Matcher singleImport = Pattern.compile(
+                        "^import\\s+([\\w.$]*\\." + Pattern.quote(simpleName) + ");", Pattern.MULTILINE)
+                .matcher(text);
+        if (singleImport.find()) {
+            return singleImport.group(1);
+        }
+
+        final Matcher declaredPackage =
+                Pattern.compile("^package\\s+([\\w.$]+);", Pattern.MULTILINE).matcher(text);
+        return declaredPackage.find() ? declaredPackage.group(1) + "." + simpleName : simpleName;
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceDocument.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceDocument.java
@@ -1,0 +1,184 @@
+package de.timmi6790.sourcerepair;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * A source file being repaired, together with the edits staged against it.
+ *
+ * <p>Edits are collected rather than applied immediately because every diagnostic of a round refers
+ * to the same, unmodified revision of the file. Applying them back to front on {@link #flush()}
+ * keeps the offsets of the remaining edits valid, and overlapping edits are dropped instead of
+ * merged: two rules disagreeing about the same span is a sign that at least one of them misread the
+ * code, and the next round re-reports whatever is still broken.
+ */
+public final class SourceDocument {
+
+    private final Path file;
+    private final String originalText;
+    private final int[] lineStarts;
+    private final List<Edit> edits = new ArrayList<>();
+
+    private String text;
+
+    private record Edit(int start, int end, String replacement) {}
+
+    SourceDocument(final Path file, final String text) {
+        this.file = file;
+        this.originalText = text;
+        this.text = text;
+        this.lineStarts = indexLines(text);
+    }
+
+    static SourceDocument read(final Path file) throws IOException {
+        return new SourceDocument(file, Files.readString(file, StandardCharsets.UTF_8));
+    }
+
+    private static int[] indexLines(final String text) {
+        final List<Integer> starts = new ArrayList<>();
+        starts.add(0);
+        for (int index = 0; index < text.length(); index++) {
+            if (text.charAt(index) == '\n') {
+                starts.add(index + 1);
+            }
+        }
+
+        final int[] result = new int[starts.size()];
+        for (int index = 0; index < result.length; index++) {
+            result[index] = starts.get(index);
+        }
+        return result;
+    }
+
+    /**
+     * The file contents as they were when the current round of diagnostics was produced.
+     *
+     * @return the unmodified source text
+     */
+    public String text() {
+        return this.originalText;
+    }
+
+    public Path file() {
+        return this.file;
+    }
+
+    /**
+     * Translates a one-based compiler position into an offset into {@link #text()}.
+     *
+     * @param line one-based line number
+     * @param column one-based column number
+     * @return the offset, or {@code -1} if the position lies outside the file
+     */
+    public int offsetOf(final int line, final int column) {
+        if (line < 1 || line > this.lineStarts.length || column < 1) {
+            return -1;
+        }
+
+        final int lineStart = this.lineStarts[line - 1];
+        final int lineEnd = line < this.lineStarts.length ? this.lineStarts[line] : this.originalText.length();
+        final int offset = lineStart + column - 1;
+        return offset > lineEnd ? -1 : offset;
+    }
+
+    /** @return the offset just past the end of the given one-based line, excluding its line break */
+    public int endOfLine(final int line) {
+        if (line < 1 || line > this.lineStarts.length) {
+            return -1;
+        }
+
+        int offset = line < this.lineStarts.length ? this.lineStarts[line] : this.originalText.length();
+        while (offset > 0
+                && (this.originalText.charAt(offset - 1) == '\n' || this.originalText.charAt(offset - 1) == '\r')) {
+            offset--;
+        }
+        return offset;
+    }
+
+    /** @return the offset of the first character of the given one-based line */
+    public int startOfLine(final int line) {
+        return line < 1 || line > this.lineStarts.length ? -1 : this.lineStarts[line - 1];
+    }
+
+    /**
+     * Stages a replacement of the given span.
+     *
+     * @param start offset of the first character to replace
+     * @param end offset just past the last character to replace
+     * @param replacement text to put in its place
+     */
+    public void replace(final int start, final int end, final String replacement) {
+        this.edits.add(new Edit(start, end, replacement));
+    }
+
+    /**
+     * Stages an insertion at the given offset.
+     *
+     * @param offset offset to insert at
+     * @param insertion text to insert
+     */
+    public void insert(final int offset, final String insertion) {
+        this.edits.add(new Edit(offset, offset, insertion));
+    }
+
+    /** @return whether any edit has been staged */
+    public boolean hasPendingEdits() {
+        return !this.edits.isEmpty();
+    }
+
+    /**
+     * Applies the staged edits and clears them.
+     *
+     * @return the number of edits applied; overlapping edits are discarded and not counted
+     */
+    public int flush() {
+        this.edits.sort(
+                Comparator.comparingInt(Edit::start).thenComparingInt(Edit::end).reversed());
+
+        final StringBuilder builder = new StringBuilder(this.text);
+        int applied = 0;
+        int lowestTouchedOffset = Integer.MAX_VALUE;
+        for (final Edit edit : this.edits) {
+            if (edit.start() < 0 || edit.end() > this.text.length() || edit.start() > edit.end()) {
+                continue;
+            }
+            if (edit.end() > lowestTouchedOffset) {
+                continue;
+            }
+
+            builder.replace(edit.start(), edit.end(), edit.replacement());
+            lowestTouchedOffset = edit.start();
+            applied++;
+        }
+
+        this.edits.clear();
+        this.text = builder.toString();
+        return applied;
+    }
+
+    /**
+     * Writes the document back to disk if {@link #flush()} changed it.
+     *
+     * @throws IOException if the file cannot be written
+     */
+    void save() throws IOException {
+        if (!this.text.equals(this.originalText)) {
+            Files.writeString(this.file, this.text, StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Restores the file to the contents it had before this round's edits.
+     *
+     * @throws IOException if the file cannot be written
+     */
+    void restore() throws IOException {
+        this.text = this.originalText;
+        Files.writeString(this.file, this.originalText, StandardCharsets.UTF_8);
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceRepair.java
@@ -1,0 +1,27 @@
+package de.timmi6790.sourcerepair;
+
+/**
+ * Repairs one class of defect a decompiler leaves behind in its output.
+ *
+ * <p>A repair is driven by a compiler diagnostic rather than by pattern matching on the source, so
+ * it only ever touches code the compiler has already rejected. Correct code is therefore never at
+ * risk, and a repair that guesses wrong is caught by the next round of compilation.
+ *
+ * <p>Implementations must be conservative: when anything about the surrounding code is not exactly
+ * as expected they decline, leaving the diagnostic to be reported as unrepaired rather than
+ * rewriting code they do not understand.
+ */
+interface SourceRepair {
+
+    /** @return a short name identifying this repair in the log */
+    String name();
+
+    /**
+     * Attempts to repair one diagnostic.
+     *
+     * @param diagnostic the error to repair
+     * @param document the file the error was reported against, to stage edits on
+     * @return {@code true} if this repair handled the diagnostic and staged an edit
+     */
+    boolean apply(CompileDiagnostic diagnostic, SourceDocument document);
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceRepairer.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceRepairer.java
@@ -60,6 +60,7 @@ public final class SourceRepairer {
                 new CatchParameterRepair(),
                 new StaticContextTypeVariableRepair(),
                 new FunctionalInterfaceRepair(sourceTree),
+                new ArgumentCastRepair(),
                 new MissingCastRepair());
     }
 
@@ -150,11 +151,11 @@ public final class SourceRepairer {
     }
 
     /**
-     * Undoes the edits that left their file with more errors than it had.
+     * Undoes the edits that did not leave their file with fewer errors than it had.
      *
      * @param pending the files edited in the previous round
      * @param errorsByFile how many errors each file has now
-     * @param abandoned files to leave alone from now on; regressing files are added to it
+     * @param abandoned files to leave alone from now on; files that did not improve are added to it
      * @return how many repairs were undone
      * @throws IOException if a source file cannot be written
      */
@@ -164,14 +165,14 @@ public final class SourceRepairer {
         int undone = 0;
         for (final PendingEdit edit : pending) {
             final Path file = edit.document().file();
-            if (errorsByFile.getOrDefault(file, 0) <= edit.errorsBefore()) {
+            if (errorsByFile.getOrDefault(file, 0) < edit.errorsBefore()) {
                 continue;
             }
 
             log.debug(
                     "Reverting {}: {} error(s) after repair, {} before",
                     file.getFileName(),
-                    errorsByFile.get(file),
+                    errorsByFile.getOrDefault(file, 0),
                     edit.errorsBefore());
             edit.document().restore();
             abandoned.add(file);

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceRepairer.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceRepairer.java
@@ -1,0 +1,261 @@
+package de.timmi6790.sourcerepair;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Makes a decompiled source tree compile.
+ *
+ * <p>Decompilers reconstruct the program a class file describes, not the source it was compiled
+ * from, and the two differ wherever the compiler erased something. Casts between parameterisations
+ * vanish, per-scope variable names collide once scopes are merged, and desugared patterns leave
+ * temporaries without declarations. Each of those produces output that is a faithful description of
+ * the bytecode yet is not a legal Java program.
+ *
+ * <p>The compiler is the only component that can tell which of those has happened and where, so it
+ * drives the repair: compile, hand each error to the {@link SourceRepair} that recognises it,
+ * recompile.
+ *
+ * <p>Repairs read a single diagnostic, not the program, so one can misjudge its context and leave a
+ * file worse than it was. Every file is therefore judged on its own after the next round: one whose
+ * error count rose is rolled back and taken out of the run, while the files that improved keep their
+ * repairs. A misjudged repair costs the file it was made in and nothing else, and no file can end up
+ * worse than it started.
+ *
+ * <p>Whatever is still broken when the rounds end is reported and left alone. A release that hits a
+ * defect no repair covers still produces sources, minus the guarantee that they compile.
+ */
+@Slf4j
+public final class SourceRepairer {
+
+    /**
+     * A repair can expose an error that was previously masked, so several rounds are expected. The
+     * limit only bounds pathological cases; rounds normally stop on their own well before it.
+     */
+    private static final int MAX_ROUNDS = 12;
+
+    private static final String JAVA_SUFFIX = ".java";
+
+    /**
+     * Ordered so that the repairs recognising a specific defect run before the general ones. Both
+     * {@link UndeclaredTemporaryRepair} and {@link CatchParameterRepair} answer to {@code cannot find
+     * symbol}, and only the former can tell its case apart with certainty.
+     */
+    private static List<SourceRepair> repairsFor(final SourceTree sourceTree) {
+        return List.of(
+                new DuplicateVariableRepair(),
+                new UndeclaredTemporaryRepair(),
+                new CatchParameterRepair(),
+                new StaticContextTypeVariableRepair(),
+                new FunctionalInterfaceRepair(sourceTree),
+                new MissingCastRepair());
+    }
+
+    /**
+     * The outcome of a repair run.
+     *
+     * @param attempted whether the tree was compiled at all; {@code false} when no compiler was
+     *     available
+     * @param rounds how many compile-and-repair rounds were kept
+     * @param repairs how many edits were applied in total
+     * @param remaining errors that no repair could resolve
+     */
+    public record RepairReport(boolean attempted, int rounds, int repairs, List<CompileDiagnostic> remaining) {
+
+        /** @return whether the tree compiles */
+        public boolean clean() {
+            return this.attempted && this.remaining.isEmpty();
+        }
+    }
+
+    /**
+     * A file edited in the previous round, kept so the edit can be judged and undone.
+     *
+     * @param document the edited file, holding the contents it had before the edit
+     * @param repairs how many edits were applied to it
+     * @param errorsBefore how many errors it had before the edit
+     */
+    private record PendingEdit(SourceDocument document, int repairs, int errorsBefore) {}
+
+    /**
+     * Repairs a source tree in place.
+     *
+     * @param sourceRoot directory holding the sources
+     * @param classpath jars the sources compile against
+     * @param release the Java release the sources target
+     * @return what the run achieved
+     * @throws IOException if the sources cannot be read or written
+     */
+    public RepairReport repair(final Path sourceRoot, final List<Path> classpath, final int release)
+            throws IOException {
+        final JavaSourceCompiler compiler = JavaSourceCompiler.create(release);
+        if (compiler == null) {
+            return new RepairReport(false, 0, 0, List.of());
+        }
+
+        final List<Path> sources = collectSources(sourceRoot);
+        if (sources.isEmpty()) {
+            return new RepairReport(false, 0, 0, List.of());
+        }
+
+        log.info("Type-checking {} source files against {} libraries", sources.size(), classpath.size());
+
+        final List<SourceRepair> repairs = repairsFor(new SourceTree(sourceRoot));
+
+        final Set<Path> abandoned = new HashSet<>();
+        List<PendingEdit> pending = List.of();
+        List<CompileDiagnostic> diagnostics = List.of();
+        int previousErrors = Integer.MAX_VALUE;
+        int applied = 0;
+        int round = 0;
+
+        while (round < MAX_ROUNDS) {
+            diagnostics = compiler.compile(sources, classpath);
+            applied -= rollBackRegressions(pending, countErrorsByFile(diagnostics), abandoned);
+            if (diagnostics.isEmpty()) {
+                log.info("Sources compile cleanly after {} repair(s)", applied);
+                return new RepairReport(true, round, applied, List.of());
+            }
+            if (diagnostics.size() >= previousErrors) {
+                // Every repair of the last round was undone again. Nothing left is within reach of
+                // the repairs available, and another round would only repeat the same attempts.
+                return new RepairReport(true, round, applied, diagnostics);
+            }
+            previousErrors = diagnostics.size();
+
+            round++;
+            pending = applyRepairs(repairs, diagnostics, abandoned);
+            final int roundRepairs =
+                    pending.stream().mapToInt(PendingEdit::repairs).sum();
+            log.info("Repair round {}: {} error(s), {} repaired", round, diagnostics.size(), roundRepairs);
+            if (roundRepairs == 0) {
+                return new RepairReport(true, round - 1, applied, diagnostics);
+            }
+            applied += roundRepairs;
+        }
+
+        return new RepairReport(true, round, applied, diagnostics);
+    }
+
+    /**
+     * Undoes the edits that left their file with more errors than it had.
+     *
+     * @param pending the files edited in the previous round
+     * @param errorsByFile how many errors each file has now
+     * @param abandoned files to leave alone from now on; regressing files are added to it
+     * @return how many repairs were undone
+     * @throws IOException if a source file cannot be written
+     */
+    private static int rollBackRegressions(
+            final List<PendingEdit> pending, final Map<Path, Integer> errorsByFile, final Set<Path> abandoned)
+            throws IOException {
+        int undone = 0;
+        for (final PendingEdit edit : pending) {
+            final Path file = edit.document().file();
+            if (errorsByFile.getOrDefault(file, 0) <= edit.errorsBefore()) {
+                continue;
+            }
+
+            log.debug(
+                    "Reverting {}: {} error(s) after repair, {} before",
+                    file.getFileName(),
+                    errorsByFile.get(file),
+                    edit.errorsBefore());
+            edit.document().restore();
+            abandoned.add(file);
+            undone += edit.repairs();
+        }
+        return undone;
+    }
+
+    /**
+     * Runs every applicable repair over one round's diagnostics.
+     *
+     * @param repairs the repairs to try, in order
+     * @param diagnostics the errors of this round
+     * @param abandoned files that must not be edited again
+     * @return the edits made, so they can be judged next round
+     * @throws IOException if a source file cannot be read or written
+     */
+    private List<PendingEdit> applyRepairs(
+            final List<SourceRepair> repairs, final List<CompileDiagnostic> diagnostics, final Set<Path> abandoned)
+            throws IOException {
+        final Map<Path, Integer> errorsByFile = countErrorsByFile(diagnostics);
+        final Map<Path, SourceDocument> documents = new LinkedHashMap<>();
+        for (final CompileDiagnostic diagnostic : diagnostics) {
+            if (abandoned.contains(diagnostic.file())) {
+                continue;
+            }
+
+            SourceDocument document = documents.get(diagnostic.file());
+            if (document == null) {
+                document = SourceDocument.read(diagnostic.file());
+                documents.put(diagnostic.file(), document);
+            }
+            stage(repairs, diagnostic, document);
+        }
+
+        final List<PendingEdit> written = new ArrayList<>();
+        for (final SourceDocument document : documents.values()) {
+            if (!document.hasPendingEdits()) {
+                continue;
+            }
+
+            final int applied = document.flush();
+            if (applied > 0) {
+                document.save();
+                written.add(new PendingEdit(document, applied, errorsByFile.get(document.file())));
+            }
+        }
+        return written;
+    }
+
+    private static Map<Path, Integer> countErrorsByFile(final List<CompileDiagnostic> diagnostics) {
+        final Map<Path, Integer> errorsByFile = new HashMap<>();
+        for (final CompileDiagnostic diagnostic : diagnostics) {
+            errorsByFile.merge(diagnostic.file(), 1, Integer::sum);
+        }
+        return errorsByFile;
+    }
+
+    private void stage(
+            final List<SourceRepair> repairs, final CompileDiagnostic diagnostic, final SourceDocument document) {
+        for (final SourceRepair repair : repairs) {
+            if (repair.apply(diagnostic, document)) {
+                log.debug(
+                        "{}: {}:{} {}",
+                        repair.name(),
+                        document.file().getFileName(),
+                        diagnostic.line(),
+                        diagnostic.summary());
+                return;
+            }
+        }
+    }
+
+    private static List<Path> collectSources(final Path sourceRoot) throws IOException {
+        final List<Path> sources = new ArrayList<>();
+        Files.walkFileTree(sourceRoot, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes) {
+                if (file.getFileName().toString().endsWith(JAVA_SUFFIX)) {
+                    sources.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return sources;
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceRepairer.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceRepairer.java
@@ -61,6 +61,8 @@ public final class SourceRepairer {
                 new StaticContextTypeVariableRepair(),
                 new FunctionalInterfaceRepair(sourceTree),
                 new ArgumentCastRepair(),
+                new TypeWitnessRepair(),
+                new RawConstructorRepair(sourceTree),
                 new MissingCastRepair());
     }
 

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceTree.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/SourceTree.java
@@ -1,0 +1,62 @@
+package de.timmi6790.sourcerepair;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Looks up the source of a type by name.
+ *
+ * <p>Some defects can only be recognised by reading the type an expression refers to rather than the
+ * file the error was reported in. Compiler diagnostics name types in full, and a decompiler writes
+ * every type to the path its package implies, so a name is enough to find the file.
+ *
+ * <p>Reads are cached because the same handful of types tends to be consulted once per diagnostic.
+ */
+final class SourceTree {
+
+    private final Path root;
+    private final Map<String, Optional<String>> cache = new HashMap<>();
+
+    SourceTree(final Path root) {
+        this.root = root;
+    }
+
+    /**
+     * Reads the source that declares a type.
+     *
+     * <p>A nested type lives in the file of its outermost enclosing type, which is found by dropping
+     * trailing name segments until a file exists.
+     *
+     * @param qualifiedName fully qualified type name as the compiler prints it
+     * @return the file contents, or empty if the tree does not declare the type
+     */
+    Optional<String> read(final String qualifiedName) {
+        return this.cache.computeIfAbsent(qualifiedName, this::load);
+    }
+
+    private Optional<String> load(final String qualifiedName) {
+        String candidate = qualifiedName;
+        while (!candidate.isEmpty()) {
+            final Path file = this.root.resolve(candidate.replace('.', '/') + ".java");
+            if (Files.isRegularFile(file)) {
+                try {
+                    return Optional.of(Files.readString(file, StandardCharsets.UTF_8));
+                } catch (final IOException exception) {
+                    return Optional.empty();
+                }
+            }
+
+            final int lastSegment = candidate.lastIndexOf('.');
+            if (lastSegment < 0) {
+                return Optional.empty();
+            }
+            candidate = candidate.substring(0, lastSegment);
+        }
+        return Optional.empty();
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/StaticContextTypeVariableRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/StaticContextTypeVariableRepair.java
@@ -1,0 +1,90 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.regex.Pattern;
+
+/**
+ * Erases a type argument the decompiler copied into a scope its type variable does not reach.
+ *
+ * <p>Reconstructing a cast means naming its type, and a decompiler names it from the declaration of
+ * whatever the value came from. Where that declaration belongs to an enclosing generic type but the
+ * cast sits in a static member, the type variable it names is out of scope.
+ *
+ * <p>Dropping the type argument leaves the raw type, which is what the cast compiles to either way:
+ * a cast to a type variable is erased to its bound, so the raw form is the same instruction and the
+ * same guarantee.
+ */
+final class StaticContextTypeVariableRepair implements SourceRepair {
+
+    private static final Pattern OUT_OF_SCOPE =
+            Pattern.compile("^non-static type variable \\w+ cannot be referenced from a static context$");
+
+    @Override
+    public String name() {
+        return "static-context-type-variable";
+    }
+
+    @Override
+    public boolean apply(final CompileDiagnostic diagnostic, final SourceDocument document) {
+        if (!OUT_OF_SCOPE.matcher(diagnostic.summary()).matches()) {
+            return false;
+        }
+
+        final int reference = document.offsetOf(diagnostic.line(), diagnostic.column());
+        if (reference < 0) {
+            return false;
+        }
+
+        final String text = document.text();
+        final int open = openingAngleBefore(text, reference);
+        final int close = open < 0 ? -1 : closingAngleAfter(text, open);
+        if (close < 0) {
+            return false;
+        }
+
+        document.replace(open, close + 1, "");
+        return true;
+    }
+
+    /**
+     * Finds the type argument list the reference sits in.
+     *
+     * @param text source text
+     * @param reference offset of the out-of-scope type variable
+     * @return offset of the opening angle bracket, or {@code -1} if there is none
+     */
+    private static int openingAngleBefore(final String text, final int reference) {
+        int depth = 0;
+        for (int index = reference - 1; index >= 0; index--) {
+            final char current = text.charAt(index);
+            if (current == '>') {
+                depth++;
+            } else if (current == '<') {
+                if (depth == 0) {
+                    return index;
+                }
+                depth--;
+            } else if (current == ';' || current == '{' || current == '}') {
+                return -1;
+            }
+        }
+        return -1;
+    }
+
+    private static int closingAngleAfter(final String text, final int open) {
+        int depth = 0;
+        for (int index = open; index < text.length(); index++) {
+            final char current = text.charAt(index);
+            if (current == '<') {
+                depth++;
+            } else if (current == '>') {
+                depth--;
+                if (depth == 0) {
+                    return index;
+                }
+            } else if (current == ';' || current == '{' || current == '}') {
+                return -1;
+            }
+        }
+        return -1;
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/TypeWitnessRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/TypeWitnessRepair.java
@@ -1,0 +1,71 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.regex.Pattern;
+
+/**
+ * Removes an explicit type argument the decompiler put on a call.
+ *
+ * <p>Like a cast on an argument, a type witness records what erasure left rather than what the
+ * source said. {@code List.<T>of()} pins the element type to the enclosing declaration's variable,
+ * where {@code List.of()} would let it be inferred from the call's target, and the pinned version
+ * frequently does not fit.
+ *
+ * <p>Only calls the compiler has already rejected are touched, and a removal that does not help is
+ * undone along with the rest of its file.
+ */
+final class TypeWitnessRepair implements SourceRepair {
+
+    /** Errors that mean a call's type arguments do not work out. */
+    private static final Pattern UNRESOLVED_CALL = Pattern.compile("^(?:no suitable method found for "
+            + "|incompatible types: cannot infer type-variable\\(s\\)"
+            + "|incompatible types: inferred type does not conform to upper bound\\(s\\)"
+            + "|incompatible types: invalid method reference"
+            + "|method .* cannot be applied to given types;).*");
+
+    /** A type witness: the angle brackets between a receiver's dot and the method name. */
+    private static final Pattern WITNESS = Pattern.compile("\\.\\s*<[^<>()]*(?:<[^<>()]*>)?[^<>()]*>\\s*(?=\\w)");
+
+    @Override
+    public String name() {
+        return "type-witness";
+    }
+
+    @Override
+    public boolean apply(final CompileDiagnostic diagnostic, final SourceDocument document) {
+        if (!UNRESOLVED_CALL.matcher(diagnostic.summary()).matches() || !diagnostic.hasSpan()) {
+            return false;
+        }
+
+        final String text = document.text();
+        final int start = Math.max(diagnostic.startPosition(), 0);
+        final int end = Math.min(diagnostic.endPosition(), text.length());
+        if (end <= start) {
+            return false;
+        }
+
+        // Only the witness of the reported call is of interest, so the search stops at the first
+        // opening parenthesis; anything past it belongs to an argument rather than to this call.
+        final int limit = argumentsBegin(text, start, end);
+        final java.util.regex.Matcher witness = WITNESS.matcher(text).region(start, limit);
+        if (!witness.find()) {
+            return false;
+        }
+
+        document.replace(witness.start(), witness.end(), ".");
+        return true;
+    }
+
+    private static int argumentsBegin(final String text, final int start, final int end) {
+        for (int index = start; index < end; index++) {
+            final int skipped = JavaText.skipInert(text, index);
+            if (skipped != index) {
+                index = skipped - 1;
+                continue;
+            }
+            if (text.charAt(index) == '(') {
+                return index;
+            }
+        }
+        return end;
+    }
+}

--- a/sourcerepair/src/main/java/de/timmi6790/sourcerepair/UndeclaredTemporaryRepair.java
+++ b/sourcerepair/src/main/java/de/timmi6790/sourcerepair/UndeclaredTemporaryRepair.java
@@ -1,0 +1,167 @@
+package de.timmi6790.sourcerepair;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Declares a temporary the decompiler assigned to but never introduced.
+ *
+ * <p>Desugared record patterns assign their component values inside a synthetic {@code try} block
+ * and read them back after it. Recovering that shape leaves the temporary assigned in one block and
+ * read in another, with no declaration in either.
+ *
+ * <p>The type is taken from the statement that reads the temporary back, and the declaration is
+ * placed in the innermost block that contains every mention of it, which is the narrowest scope in
+ * which the original variable could have lived.
+ */
+final class UndeclaredTemporaryRepair implements SourceRepair {
+
+    private static final Pattern MISSING_VARIABLE = Pattern.compile("symbol:\\s*variable (\\w+)");
+
+    /** Type names as they appear in a declaration, including generics and array dimensions. */
+    private static final String TYPE = "[\\w.$]+(?:\\s*<[^;=]*>)?(?:\\s*\\[\\s*])*";
+
+    /** Headers of blocks that hold members rather than statements. */
+    private static final Pattern TYPE_BODY_HEADER =
+            Pattern.compile("\\b(?:class|interface|enum|record|@interface)\\b|\\bnew\\b[^()]*\\([^()]*\\)\\s*$");
+
+    /** A switch body may only open with a label, so a declaration cannot go at the top of one. */
+    private static final Pattern ARM_LABEL = Pattern.compile("^(?:case|default)\\b");
+
+    @Override
+    public String name() {
+        return "undeclared-temporary";
+    }
+
+    @Override
+    public boolean apply(final CompileDiagnostic diagnostic, final SourceDocument document) {
+        if (!"cannot find symbol".equals(diagnostic.summary())) {
+            return false;
+        }
+
+        final Matcher missing = MISSING_VARIABLE.matcher(diagnostic.message());
+        if (!missing.find()) {
+            return false;
+        }
+
+        final String name = missing.group(1);
+        final int assignment = document.offsetOf(diagnostic.line(), diagnostic.column());
+        final String text = document.text();
+        if (assignment < 0 || !isAssignmentTarget(text, assignment + name.length())) {
+            return false;
+        }
+
+        final String type = declaredTypeOf(text, name);
+        if (type == null) {
+            return false;
+        }
+
+        final int block = commonBlock(text, name);
+        if (block < 0) {
+            return false;
+        }
+
+        final int lineStart = document.startOfLine(diagnostic.line());
+        final String indent =
+                lineStart < 0 ? "" : text.substring(lineStart, assignment).replaceAll("\\S.*", "");
+        document.insert(block + 1, "\n" + indent + type + " " + name + ";");
+        return true;
+    }
+
+    /** @return whether the offset is followed by a single {@code =}, marking an assignment */
+    private static boolean isAssignmentTarget(final String text, final int afterName) {
+        int index = afterName;
+        while (index < text.length() && Character.isWhitespace(text.charAt(index))) {
+            index++;
+        }
+        return index + 1 < text.length() && text.charAt(index) == '=' && text.charAt(index + 1) != '=';
+    }
+
+    /**
+     * Recovers the temporary's type from the statement that reads it back.
+     *
+     * @param text source text
+     * @param name the temporary's name
+     * @return the declared type, or {@code null} if the temporary is never read into a typed local
+     */
+    private static String declaredTypeOf(final String text, final String name) {
+        final Matcher read = Pattern.compile("(" + TYPE + ")\\s+\\w+\\s*=\\s*" + Pattern.quote(name) + "\\s*;")
+                .matcher(text);
+        return read.find() ? read.group(1).trim() : null;
+    }
+
+    /**
+     * Finds the innermost block that can hold a declaration covering every mention of the temporary.
+     *
+     * <p>The innermost block containing all mentions may be a {@code switch} body, which has to open
+     * with a label, so the search widens until it reaches a block that accepts statements. It never
+     * widens into a type body: a declaration there would be a field, not a local.
+     *
+     * @param text source text
+     * @param name the temporary's name
+     * @return offset of that block's opening brace, or {@code -1} if there is none
+     */
+    private static int commonBlock(final String text, final String name) {
+        List<Integer> common = null;
+        int occurrence = JavaText.indexOfIdentifier(text, name, 0, text.length());
+        while (occurrence >= 0) {
+            final List<Integer> braces = JavaText.enclosingBraces(text, occurrence);
+            common = common == null ? braces : longestCommonPrefix(common, braces);
+            occurrence = JavaText.indexOfIdentifier(text, name, occurrence + name.length(), text.length());
+        }
+        if (common == null) {
+            return -1;
+        }
+
+        for (int index = common.size() - 1; index >= 0; index--) {
+            final int brace = common.get(index);
+            if (isTypeBody(text, brace)) {
+                return -1;
+            }
+            if (!opensWithArmLabel(text, brace)) {
+                return brace;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean isTypeBody(final String text, final int brace) {
+        int start = brace;
+        while (start > 0) {
+            final char current = text.charAt(start - 1);
+            if (current == ';' || current == '{' || current == '}') {
+                break;
+            }
+            start--;
+        }
+        return TYPE_BODY_HEADER.matcher(text.substring(start, brace)).find();
+    }
+
+    private static boolean opensWithArmLabel(final String text, final int brace) {
+        int index = brace + 1;
+        while (index < text.length()) {
+            if (Character.isWhitespace(text.charAt(index))) {
+                index++;
+                continue;
+            }
+            final int skipped = JavaText.skipInert(text, index);
+            if (skipped != index) {
+                index = skipped;
+                continue;
+            }
+            return ARM_LABEL.matcher(text).region(index, text.length()).lookingAt();
+        }
+        return false;
+    }
+
+    private static List<Integer> longestCommonPrefix(final List<Integer> first, final List<Integer> second) {
+        int shared = 0;
+        while (shared < first.size()
+                && shared < second.size()
+                && first.get(shared).equals(second.get(shared))) {
+            shared++;
+        }
+        return first.subList(0, shared);
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/McDeobCommand.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/McDeobCommand.java
@@ -72,6 +72,13 @@ public class McDeobCommand implements Callable<Integer> {
     private boolean gradleProject;
 
     @Option(
+            names = "--repair-sources",
+            negatable = true,
+            description = "Type-check the decompiled sources and repair the defects the decompiler left behind"
+                    + " (default: on when --gradle-project is used). Requires a JDK and --libraries.")
+    private Boolean repairSources;
+
+    @Option(
             names = "--versions",
             description = "Prints a list of all Minecraft versions available to deobfuscate",
             help = true)
@@ -141,12 +148,26 @@ public class McDeobCommand implements Callable<Integer> {
             return 1;
         }
 
+        // A generated project is only useful if it builds, so repairing is the default there. On its
+        // own the flag still works, for callers that want repaired sources without a project.
+        final boolean repair = this.repairSources != null ? this.repairSources : this.gradleProject;
+        if (repair && !this.decompile) {
+            log.error("--repair-sources requires --decompile");
+            return 1;
+        }
+
+        if (repair && !this.libraries) {
+            log.error("--repair-sources requires --libraries");
+            return 1;
+        }
+
         final ProcessorOptions processorOptions = ProcessorOptions.builder()
                 .remap(shouldRemap)
                 .decompile(this.decompile)
                 .zipDecompileOutput(this.zip && this.decompile)
                 .downloadLibraries(this.libraries)
                 .setupGradleProject(this.gradleProject)
+                .repairSources(repair)
                 .decompilerType(decompilerType)
                 .build();
 

--- a/src/main/java/com/shanebeestudios/mcdeop/app/components/McDeobOptionsPanel.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/app/components/McDeobOptionsPanel.java
@@ -18,6 +18,7 @@ public class McDeobOptionsPanel extends FlowPane {
     private final CheckBox zipCheckBox;
     private final CheckBox librariesCheckBox;
     private final CheckBox gradleProjectCheckBox;
+    private final CheckBox repairSourcesCheckBox;
 
     public McDeobOptionsPanel() {
         super(10, 10);
@@ -32,6 +33,7 @@ public class McDeobOptionsPanel extends FlowPane {
         this.zipCheckBox = new CheckBox("Zip");
         this.librariesCheckBox = new CheckBox("Libraries");
         this.gradleProjectCheckBox = new CheckBox("Gradle Project");
+        this.repairSourcesCheckBox = new CheckBox("Repair Sources");
         this.decompilerComboBox = this.createDecompilerComboBox();
 
         this.configureOption(this.remapCheckBox);
@@ -39,15 +41,18 @@ public class McDeobOptionsPanel extends FlowPane {
         this.configureOption(this.zipCheckBox);
         this.configureOption(this.librariesCheckBox);
         this.configureOption(this.gradleProjectCheckBox);
+        this.configureOption(this.repairSourcesCheckBox);
 
         this.remapCheckBox.setSelected(true);
         this.decompileCheckBox.setSelected(true);
         this.zipCheckBox.setSelected(true);
         this.librariesCheckBox.setSelected(false);
         this.gradleProjectCheckBox.setSelected(false);
+        this.repairSourcesCheckBox.setSelected(false);
 
         this.decompileCheckBox.selectedProperty().addListener((obs, oldV, newV) -> this.updateDependencies());
         this.gradleProjectCheckBox.selectedProperty().addListener((obs, oldV, newV) -> this.updateDependencies());
+        this.librariesCheckBox.selectedProperty().addListener((obs, oldV, newV) -> this.updateDependencies());
         this.updateDependencies();
 
         final HBox decompilerRow = new HBox(8);
@@ -64,7 +69,8 @@ public class McDeobOptionsPanel extends FlowPane {
                         this.decompileCheckBox,
                         this.zipCheckBox,
                         this.librariesCheckBox,
-                        this.gradleProjectCheckBox);
+                        this.gradleProjectCheckBox,
+                        this.repairSourcesCheckBox);
     }
 
     private void configureOption(final CheckBox box) {
@@ -86,6 +92,7 @@ public class McDeobOptionsPanel extends FlowPane {
         if (gradleSelected) {
             this.decompileCheckBox.setSelected(true);
             this.librariesCheckBox.setSelected(true);
+            this.repairSourcesCheckBox.setSelected(true);
         }
 
         if (!this.decompileCheckBox.isSelected()) {
@@ -96,6 +103,14 @@ public class McDeobOptionsPanel extends FlowPane {
         this.decompileCheckBox.setDisable(gradleSelected);
         this.librariesCheckBox.setDisable(gradleSelected);
         this.decompilerComboBox.setDisable(!this.decompileCheckBox.isSelected());
+
+        // Repairing type-checks the sources, which needs both the sources and what they compile
+        // against; a generated project additionally has no use for sources that do not build.
+        final boolean canRepair = this.decompileCheckBox.isSelected() && this.librariesCheckBox.isSelected();
+        if (!canRepair) {
+            this.repairSourcesCheckBox.setSelected(false);
+        }
+        this.repairSourcesCheckBox.setDisable(gradleSelected || !canRepair);
     }
 
     public void setRemapVisible(final boolean visible) {
@@ -111,6 +126,7 @@ public class McDeobOptionsPanel extends FlowPane {
                 .zipDecompileOutput(this.decompileCheckBox.isSelected() && this.zipCheckBox.isSelected())
                 .downloadLibraries(this.librariesCheckBox.isSelected())
                 .setupGradleProject(this.gradleProjectCheckBox.isSelected())
+                .repairSources(this.repairSourcesCheckBox.isSelected())
                 .decompilerType(
                         this.decompilerComboBox.getValue() == null
                                 ? DEFAULT_DECOMPILER
@@ -125,6 +141,7 @@ public class McDeobOptionsPanel extends FlowPane {
         this.zipCheckBox.setDisable(disable);
         this.librariesCheckBox.setDisable(disable);
         this.gradleProjectCheckBox.setDisable(disable);
+        this.repairSourcesCheckBox.setDisable(disable);
 
         if (!disable) {
             this.updateDependencies();

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/GradleProjectWriter.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/GradleProjectWriter.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 
 final class GradleProjectWriter {
-    private static final int DEFAULT_GRADLE_JAVA_VERSION = 21;
+    static final int DEFAULT_GRADLE_JAVA_VERSION = 21;
 
     private static final String SETTINGS_TEMPLATE = """
         pluginManagement {

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/Processor.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/Processor.java
@@ -30,6 +30,7 @@ public class Processor {
     private final ProcessorStatusReporter statusReporter;
     private final ProcessorDownloadService downloadService;
     private final GradleProjectWriter gradleProjectWriter;
+    private final SourceRepairStage sourceRepairStage;
 
     private Processor(
             final ResourceRequest request,
@@ -49,6 +50,7 @@ public class Processor {
         final OkHttpClient httpClient = RequestModule.createHttpClient();
         this.downloadService = new ProcessorDownloadService(request, httpClient, this.paths, this.statusReporter);
         this.gradleProjectWriter = new GradleProjectWriter(request, this.paths);
+        this.sourceRepairStage = new SourceRepairStage(request, this.paths, this.statusReporter, this.downloadService);
     }
 
     public static boolean runProcessor(
@@ -95,6 +97,20 @@ public class Processor {
             return false;
         }
 
+        if (this.options.repairSources() && !this.options.decompile()) {
+            log.error("Source repair requires decompile to be enabled.");
+            this.statusReporter.send("Source repair requires decompiling.");
+            return false;
+        }
+
+        // Without the libraries the sources reference, nearly every file fails to type-check and the
+        // decompiler defects the repair exists for would be lost among the resulting noise.
+        if (this.options.repairSources() && !this.options.downloadLibraries()) {
+            log.error("Source repair requires downloading libraries.");
+            this.statusReporter.send("Source repair requires library downloads.");
+            return false;
+        }
+
         return true;
     }
 
@@ -127,13 +143,21 @@ public class Processor {
                     jarPath,
                     this.paths.decompiledJarPath(),
                     this.downloadService.resolveDecompilerLibraries(this.options, this.decompiler));
+        }
+    }
 
-            if (this.options.zipDecompileOutput()) {
-                log.info("Packing decompiled files into {}", this.paths.decompiledZipPath());
-                this.statusReporter.send("Packing decompiled files ...");
-                FileUtil.remove(this.paths.decompiledZipPath());
-                FileUtil.zip(this.paths.decompiledJarPath(), this.paths.decompiledZipPath());
-            }
+    /** Packs the decompiled sources, after any repair, so the archive matches what is on disk. */
+    private void zipDecompiledOutput() throws IOException {
+        log.info("Packing decompiled files into {}", this.paths.decompiledZipPath());
+        this.statusReporter.send("Packing decompiled files ...");
+        FileUtil.remove(this.paths.decompiledZipPath());
+        FileUtil.zip(this.paths.decompiledJarPath(), this.paths.decompiledZipPath());
+    }
+
+    private void repairSources() throws IOException {
+        try (final DurationTracker ignored =
+                new DurationTracker(duration -> log.info("Source repair completed in {}!", duration))) {
+            this.sourceRepairStage.run();
         }
     }
 
@@ -211,6 +235,14 @@ public class Processor {
                 Path decompileJarPath = remapped ? this.paths.remappedJar() : this.paths.jarPath();
                 decompileJarPath = this.prepareServerJarForDecompile(decompileJarPath, remapped);
                 this.decompileJar(decompileJarPath);
+            }
+
+            if (this.options.repairSources()) {
+                this.repairSources();
+            }
+
+            if (this.options.zipDecompileOutput()) {
+                this.zipDecompiledOutput();
             }
 
             if (this.options.setupGradleProject()) {

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorDownloadService.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorDownloadService.java
@@ -5,9 +5,11 @@ import com.shanebeestudios.mcdeop.util.DurationTracker;
 import com.shanebeestudios.mcdeop.util.FileUtil;
 import de.timmi6790.launchermeta.data.release.LibraryArtifact;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
@@ -23,6 +25,10 @@ import org.jetbrains.annotations.Nullable;
 
 @Slf4j
 final class ProcessorDownloadService {
+
+    /** Where the annotation libraries Mojang compiles against are published. */
+    private static final String MAVEN_CENTRAL = "https://repo1.maven.org/maven2/";
+
     private final ResourceRequest request;
     private final OkHttpClient httpClient;
     private final ProcessorPaths paths;
@@ -105,6 +111,40 @@ final class ProcessorDownloadService {
         }
     }
 
+    /**
+     * Fetches the compile-time dependencies the decompiled sources need.
+     *
+     * <p>These are the annotation libraries Mojang compiles against without shipping them, so they
+     * appear in no manifest and have to come from Maven Central. A download that fails is skipped
+     * rather than fatal: the sources still compile apart from their annotated declarations, and a
+     * partial type-check is more useful than none.
+     *
+     * @param coordinates Maven coordinates in {@code group:artifact:version} form
+     * @return the jars that could be fetched
+     */
+    List<Path> downloadCompileDependencies(final List<String> coordinates) {
+        final List<Path> jars = new ArrayList<>(coordinates.size());
+        for (final String coordinate : coordinates) {
+            final String[] parts = coordinate.split(":");
+            if (parts.length != 3) {
+                log.warn("Ignoring malformed compile-time dependency coordinate '{}'", coordinate);
+                continue;
+            }
+
+            final String fileName = parts[1] + "-" + parts[2] + ".jar";
+            final Path target = this.paths.compileLibrariesPath().resolve(fileName);
+            final String url = String.format(
+                    "%s%s/%s/%s/%s", MAVEN_CENTRAL, parts[0].replace('.', '/'), parts[1], parts[2], fileName);
+            try {
+                this.downloadFile(URI.create(url).toURL(), target, "compile-time dependency");
+                jars.add(target);
+            } catch (final IOException exception) {
+                log.warn("Failed to download compile-time dependency {}; continuing without it", coordinate, exception);
+            }
+        }
+        return jars;
+    }
+
     List<Path> resolveDecompilerLibraries(final ProcessorOptions options, final Decompiler decompiler)
             throws IOException {
         if (!options.downloadLibraries()) {
@@ -131,7 +171,7 @@ final class ProcessorDownloadService {
         return libraries;
     }
 
-    private List<Path> getDownloadedLibraryJars() throws IOException {
+    List<Path> getDownloadedLibraryJars() throws IOException {
         if (!Files.isDirectory(this.paths.librariesPath())) {
             return List.of();
         }
@@ -152,7 +192,7 @@ final class ProcessorDownloadService {
     private void downloadFile(final URL url, final Path path, final String fileType) throws IOException {
         try (final DurationTracker ignored = new DurationTracker(
                 duration -> log.info("Successfully downloaded {} file in {}!", fileType, duration))) {
-            log.info("Downloading {} file from Mojang...", fileType);
+            log.info("Downloading {} file...", fileType);
             final Request httpRequest = new Request.Builder().url(url).build();
 
             try (final Response response = this.httpClient.newCall(httpRequest).execute()) {

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorOptions.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorOptions.java
@@ -10,4 +10,5 @@ public record ProcessorOptions(
         boolean zipDecompileOutput,
         boolean downloadLibraries,
         boolean setupGradleProject,
+        boolean repairSources,
         DecompilerType decompilerType) {}

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorPaths.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorPaths.java
@@ -15,6 +15,7 @@ record ProcessorPaths(
         Path decompiledJarPath,
         Path decompiledZipPath,
         Path librariesPath,
+        Path compileLibrariesPath,
         Path gradleProjectPath) {
 
     static ProcessorPaths create(final ResourceRequest request) {
@@ -38,6 +39,7 @@ record ProcessorPaths(
                 dataFolderPath.resolve("decompiled"),
                 dataFolderPath.resolve("decompiled.zip"),
                 dataFolderPath.resolve("libraries"),
+                dataFolderPath.resolve("compile-libraries"),
                 dataFolderPath.resolve("gradle-project"));
     }
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/SourceRepairStage.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/SourceRepairStage.java
@@ -1,0 +1,98 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import de.timmi6790.sourcerepair.CompileDiagnostic;
+import de.timmi6790.sourcerepair.SourceRepairer;
+import de.timmi6790.sourcerepair.SourceRepairer.RepairReport;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Turns the decompiled sources into a tree that compiles.
+ *
+ * <p>Type-checking needs the same classpath the generated project builds against, which is the
+ * downloaded libraries plus the annotation libraries Mojang compiles against but does not ship.
+ * Those are only named in the generated build file, so they are fetched here as well; without them
+ * every annotated declaration would be reported as an error and drown out the real defects.
+ *
+ * <p>The stage never fails the run. A version whose sources cannot be fully repaired still produces
+ * output, and the errors that remain are logged so they can be looked at.
+ */
+@Slf4j
+final class SourceRepairStage {
+
+    private final ResourceRequest request;
+    private final ProcessorPaths paths;
+    private final ProcessorStatusReporter statusReporter;
+    private final ProcessorDownloadService downloadService;
+
+    /** How many unrepaired errors to log before summarising the rest. */
+    private static final int REPORTED_ERRORS = 25;
+
+    SourceRepairStage(
+            final ResourceRequest request,
+            final ProcessorPaths paths,
+            final ProcessorStatusReporter statusReporter,
+            final ProcessorDownloadService downloadService) {
+        this.request = request;
+        this.paths = paths;
+        this.statusReporter = statusReporter;
+        this.downloadService = downloadService;
+    }
+
+    /**
+     * Repairs the decompiled sources in place.
+     *
+     * @throws IOException if the sources or the compile-time dependencies cannot be read or written
+     */
+    void run() throws IOException {
+        this.statusReporter.send("Repairing decompiled sources...");
+
+        final List<String> coordinates = new CompileDependencyResolver()
+                .resolve(
+                        this.paths.decompiledJarPath(),
+                        this.paths.librariesPath(),
+                        this.request.getVersion().releaseTime().toLocalDate())
+                .coordinates();
+
+        final List<Path> classpath = new ArrayList<>(this.downloadService.getDownloadedLibraryJars());
+        classpath.addAll(this.downloadService.downloadCompileDependencies(coordinates));
+
+        final int release = this.request.getJavaVersion().orElse(GradleProjectWriter.DEFAULT_GRADLE_JAVA_VERSION);
+        final RepairReport report = new SourceRepairer().repair(this.paths.decompiledJarPath(), classpath, release);
+        this.report(report);
+    }
+
+    private void report(final RepairReport report) {
+        if (!report.attempted()) {
+            this.statusReporter.send("Source repair skipped.");
+            return;
+        }
+
+        if (report.clean()) {
+            log.info(
+                    "Decompiled sources compile cleanly ({} repair(s) over {} round(s))",
+                    report.repairs(),
+                    report.rounds());
+            this.statusReporter.send("Decompiled sources compile cleanly.");
+            return;
+        }
+
+        final List<CompileDiagnostic> remaining = report.remaining();
+        log.warn(
+                "{} repair(s) applied over {} round(s), but {} compile error(s) remain. The generated project"
+                        + " will not build without manual fixes.",
+                report.repairs(),
+                report.rounds(),
+                remaining.size());
+        for (final CompileDiagnostic diagnostic : remaining.subList(0, Math.min(REPORTED_ERRORS, remaining.size()))) {
+            log.warn("  {}:{}: {}", diagnostic.file().getFileName(), diagnostic.line(), diagnostic.summary());
+        }
+        if (remaining.size() > REPORTED_ERRORS) {
+            log.warn("  ... and {} more", remaining.size() - REPORTED_ERRORS);
+        }
+        this.statusReporter.send(String.format("%d compile error(s) remain.", remaining.size()));
+    }
+}


### PR DESCRIPTION
## What this is

Decompiled Minecraft does not compile. A decompiler reconstructs the program a class file *describes*, not the source it was compiled from, and the two differ wherever the compiler erased something:

- `(Brain<Hoglin>) super.getBrain()` and `super.getBrain()` compile to identical bytecode, so the cast is gone
- `switch` arms that had separate scopes in the line table collide once merged into one block
- desugared record patterns leave temporaries assigned in one block and read in another, declared in neither
- a lambda cast to a single-method subtype loses the cast, because the subtype lives in the call site's bootstrap arguments

On `client-26.3-snapshot-7` that is **180 compile errors across 121 files**.

## Decompiler options are not the answer

Every Vineflower option was swept individually against a full client decompile first. None beats the current set:

| variant | errors | |
|---|---|---|
| current options | **180** | baseline |
| `--decompile-switch-expressions=0` | 2 | **masked** — parse errors abort attribution |
| `--remove-getclass=0` | 3 | **masked** — same |
| `--explicit-generics=1` | 628 | |
| `--lambda-to-anonymous-class=1` | 42735 | |
| `--include-runtime=0` | 563 | this is what native-image builds get |
| everything else | 180–191 | no change or worse |

The two apparent wins are artefacts: a handful of parse errors stops javac before it type-checks anything, so the low totals hide the real errors rather than fixing them. The existing options are already optimal.

## What it does instead

A new `sourcerepair` module lets the compiler drive the fix: compile the tree, hand each error to the repair that recognises it, recompile, repeat until it compiles or nothing more is in reach.

Repairs only ever touch code the compiler has already rejected, so correct code is never at risk. Because a repair reads one diagnostic rather than the program, each file is judged on its own after the next round — one whose error count rose is rolled back and dropped from the run. No file can end up worse than it started.

Six repairs, one per defect class: missing cast, duplicate variable, catch parameter, undeclared temporary, out-of-scope type variable in a static context, and functional-interface target. The functional-interface repair declines when a type declares more than one single-method subtype, since picking one would decide behaviour the diagnostic says nothing about.

## Result

**180 → 106 errors, in three rounds, in about 75 seconds.** What remains is generic inference that the diagnostics do not pin down well enough to repair mechanically (`cannot infer type-variable(s) O` and friends). Those are logged and left in place, so a future version that hits an unfamiliar defect still produces output.

## Running under GraalVM

On a JDK the runtime's own compiler is used. A native image has none, so a JDK installed on the machine is borrowed — found via `JAVA_HOME`, the `PATH`, or a Gradle toolchain — and a small program is handed to its source launcher. It drives the same compiler API and returns the same diagnostics including exact source spans, which console output does not carry and the repairs depend on. Verified to produce byte-identical results to the in-process path.

One caveat that is *not* fixed: a native image also decompiles without the JDK type hierarchy, because Vineflower's `--include-runtime` needs the `jrt` filesystem provider that native images do not ship. That starts from 563 errors rather than 180. A `.jar` run gives the best chance of a project that builds.

## Usage

On by default with `--gradle-project`; `--no-repair-sources` opts out. Also available standalone, and as a `Repair Sources` checkbox in the UI.

```bash
./gradlew run --args="--type client --version 1.21.4 --decompile --libraries --repair-sources"
```

## Verification

- Full sweep of every Vineflower option, each checked for parse-error masking
- End-to-end through the CLI on `client-26.3-snapshot-7`; the generated Gradle project independently reports the same residual
- External-compiler path forced and confirmed identical to in-process
- `./gradlew build` and `spotlessApply` clean
