### PR TITLE
fix(cli): stop --remap, --decompile and --zip meaning their opposite

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This section is for contributors and power users who want to run McDeob from sou
 ```
 
 - `--gradle-project` requires `--decompile` and `--libraries`.
-- `--decompiler` supports `vineflower` (default), `fernflower`, `cfr`, and `jadx`.
+- `--decompiler` supports `vineflower` (default), `fernflower`, and `jadx`.
 
 The generated project also declares the annotation libraries Mojang compiles against but does not
 publish as runtime libraries, such as `org.jetbrains:annotations` and `com.google.code.findbugs:jsr305`.

--- a/src/main/java/com/shanebeestudios/mcdeop/McDeobCommand.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/McDeobCommand.java
@@ -7,6 +7,7 @@ import com.shanebeestudios.mcdeop.processor.SourceType;
 import com.shanebeestudios.mcdeop.processor.decompiler.DecompilerType;
 import de.timmi6790.launchermeta.data.version.Version;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,7 @@ public class McDeobCommand implements Callable<Integer> {
             names = "--remap",
             negatable = true,
             defaultValue = "true",
+            fallbackValue = "true",
             description = "Remap the obfuscated source (default: ${DEFAULT-VALUE})")
     private boolean remap = true;
 
@@ -39,6 +41,7 @@ public class McDeobCommand implements Callable<Integer> {
             names = "--decompile",
             negatable = true,
             defaultValue = "true",
+            fallbackValue = "true",
             description = "Decompile classes into source files (default: ${DEFAULT-VALUE})")
     private boolean decompile = true;
 
@@ -46,20 +49,22 @@ public class McDeobCommand implements Callable<Integer> {
             names = "--zip",
             negatable = true,
             defaultValue = "true",
+            fallbackValue = "true",
             description = "Zip decompiled output (default: ${DEFAULT-VALUE})")
     private boolean zip = true;
 
     @Option(
             names = "--decompiler",
             defaultValue = "vineflower",
-            description =
-                    "Decompiler engine to use (supported: vineflower, fernflower, cfr, jadx; default: ${DEFAULT-VALUE})")
+            completionCandidates = DecompilerCandidates.class,
+            description = "Decompiler engine to use (supported: ${COMPLETION-CANDIDATES}; default: ${DEFAULT-VALUE})")
     private String decompiler;
 
     @Option(
             names = "--libraries",
             negatable = true,
             defaultValue = "false",
+            fallbackValue = "true",
             description = "Download all release libraries (default: ${DEFAULT-VALUE})")
     private boolean libraries;
 
@@ -67,6 +72,7 @@ public class McDeobCommand implements Callable<Integer> {
             names = "--gradle-project",
             negatable = true,
             defaultValue = "false",
+            fallbackValue = "true",
             description =
                     "Generate a base Gradle project using decompiled sources and downloaded libraries (default: ${DEFAULT-VALUE})")
     private boolean gradleProject;
@@ -81,6 +87,14 @@ public class McDeobCommand implements Callable<Integer> {
 
     public McDeobCommand(final VersionManager versionManager) {
         this.versionManager = versionManager;
+    }
+
+    /** Takes the advertised engines from the enum, so the help cannot name one that does not exist. */
+    static class DecompilerCandidates implements Iterable<String> {
+        @Override
+        public Iterator<String> iterator() {
+            return DecompilerType.cliValues().iterator();
+        }
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/DecompilerType.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/DecompilerType.java
@@ -1,9 +1,10 @@
 package com.shanebeestudios.mcdeop.processor.decompiler;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public enum DecompilerType {
     VINEFLOWER("vineflower", "Vineflower"),
@@ -42,7 +43,23 @@ public enum DecompilerType {
     }
 
     public static String supportedValues() {
-        return Arrays.stream(values()).map(DecompilerType::cliValue).collect(Collectors.joining(", "));
+        return String.join(", ", cliValues());
+    }
+
+    /**
+     * The values {@link #fromValue(String)} accepts.
+     *
+     * <p>Derived from the constants rather than written out, so the command line help cannot come to
+     * advertise an engine that does not exist.
+     *
+     * @return every supported CLI value, in declaration order
+     */
+    public static List<String> cliValues() {
+        final List<String> values = new ArrayList<>(values().length);
+        for (final DecompilerType type : values()) {
+            values.add(type.cliValue);
+        }
+        return values;
     }
 
     @Override


### PR DESCRIPTION
Two CLI correctness bugs, both found while working on #303.

## 1. Negatable flags are inverted

picocli assigns a negatable option **the negation of its default** when it is matched by the *positive* name, and **the default itself** when matched by the *negated* name. That happens to be right when the default is `false`, and backwards when it is `true`.

All three options that default to `true` were therefore inverted end to end. Measured against picocli 4.7.7:

| declared | `--x` | `--no-x` | absent |
|---|---|---|---|
| `defaultValue = "true"` | **false** | **true** | true |
| `defaultValue = "false"` | true | false | false |

So `--decompile` turned decompiling **off**, and `--no-decompile` turned it **on**. Same for `--remap` and `--zip`. The README's own example —

```
--type client --version 1.21.4 --remap --decompile --zip
```

— disabled all three and did nothing but download the jar.

`fallbackValue` pins what the positive form means, which leaves both forms doing what they say:

| declared | `--x` | `--no-x` | absent |
|---|---|---|---|
| `defaultValue = "true"`, `fallbackValue = "true"` | true | false | true |
| `defaultValue = "false"`, `fallbackValue = "true"` | true | false | false |

Applied to `--remap`, `--decompile`, `--zip`, `--libraries` and `--gradle-project`. The last two were already behaving correctly, but only because their default is `false`; they are pinned too so the declaration no longer depends on that coincidence.

## 2. `cfr` was advertised but never existed

The `--decompiler` help and the README both listed `cfr`. `DecompilerType` only defines `VINEFLOWER`, `FERNFLOWER` and `JADX`, so `--decompiler cfr` always failed with *"Invalid decompiler was specified"*.

Dropped rather than implemented — adding a decompiler backend is a feature decision, not a docs fix, and it would pull in a new dependency. The advertised list is now generated from the enum via `completionCandidates`, so the help and the accepted values cannot drift apart again.

```
--decompiler=<decompiler>
       Decompiler engine to use (supported: vineflower, fernflower, jadx;
         default: vineflower)
```

## Verification

- picocli semantics established in isolation across both default polarities, with and without `fallbackValue`
- End to end against `client-26.3-snapshot-7`: `--no-decompile` skips decompiling, `--decompile` performs it, `--no-zip` skips packing
- `--help` output checked
- `./gradlew build` clean
