### PR TITLE
fix: verify downloads, correct Windows zips, and cover the logic with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ files.
 - Optional zip archive (if enabled)
 - Files organized by version and selected options
 
+Downloads are verified against the SHA-1 published in Mojang's launcher manifest. An intact file is
+reused without re-downloading, and a corrupted transfer is discarded rather than processed.
+
 ## Screenshot
 
 ![McDeob UI](docs/images/ui.png)
@@ -77,6 +80,22 @@ publish as runtime libraries, such as `org.jetbrains:annotations` and `com.googl
 They are detected from the decompiled imports and resolved from Maven Central, pinned to the version
 that was current when the Minecraft version released. Imports that cannot be resolved are logged and
 listed in the generated `README.md`.
+
+### Tests
+
+```bash
+./gradlew test
+```
+
+### Build Options
+
+- `-PgithubRepoName=owner/repo` overrides the repository the update check targets. The build normally
+  reads it from the `origin` git remote; set this when building outside a git checkout.
+
+### Runtime Options
+
+- `-Dmcdeob.reconstruct.threads=N` caps the remapper's worker threads. Defaults to one per available
+  processor.
 
 ### Native Build (GluonFX)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.GradleException
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
@@ -29,7 +28,7 @@ application {
 }
 
 javafx {
-    version = "21.0.4"
+    version = libs.versions.javafx.get()
     modules = listOf("javafx.controls", "javafx.graphics")
 }
 
@@ -47,6 +46,8 @@ dependencies {
     implementation(libs.picocli)
     implementation(libs.slf4j.simple)
     implementation(libs.okhttp)
+    // Used directly by the release checker; previously reachable only through the launchermeta shadow jar.
+    implementation(libs.jackson.databind)
 
     annotationProcessor(libs.picocli.codegen)
 }
@@ -175,7 +176,9 @@ gluonfx {
 
 allprojects {
     apply {
-        plugin("java")
+        // java-library rather than java, so subprojects can separate their api from their
+        // implementation dependencies.
+        plugin("java-library")
         plugin("com.diffplug.spotless")
         plugin("io.freefair.lombok")
         plugin("com.gradleup.shadow")
@@ -189,6 +192,23 @@ allprojects {
 
     repositories {
         mavenCentral()
+    }
+
+    dependencies {
+        // Annotations are erased at build time, so compileOnly is enough. Declared explicitly because
+        // the code uses @Nullable; it previously resolved only as a transitive of the decompiler
+        // backends, where a dependency bump that dropped it would have broken compilation.
+        "compileOnly"(rootProject.libs.jetbrains.annotations)
+
+        "testImplementation"(rootProject.libs.junit.jupiter)
+        "testRuntimeOnly"(rootProject.libs.junit.platform.launcher)
+    }
+
+    tasks.withType<Test>().configureEach {
+        useJUnitPlatform()
+        testLogging {
+            events("failed")
+        }
     }
 
     spotless {
@@ -223,28 +243,42 @@ allprojects {
         withType<Javadoc> {
             options.encoding = "UTF-8"
         }
-
-        withType<ShadowJar> {
-            // https://github.com/johnrengelman/shadow/issues/857
-            // archiveClassifier.set("")
-
-            // dependsOn("distTar", "distZip")
-        }
     }
 }
 
-fun getGitRepoName(): String {
-    val process =
-        ProcessBuilder("git", "config", "--get", "remote.origin.url")
-            .redirectErrorStream(true)
-            .start()
+/**
+ * Resolved once per build: the lookup shells out to git, and it is read by two build config fields.
+ *
+ * Override with `-PgithubRepoName=owner/repo` (or a `gradle.properties` entry) when building outside
+ * a git checkout, such as from a source tarball, where the lookup cannot succeed.
+ */
+val githubRepoName: String by lazy {
+    val override = providers.gradleProperty("githubRepoName").orNull
+    if (!override.isNullOrBlank()) {
+        return@lazy override
+    }
+
     val url =
-        process.inputStream
-            .bufferedReader()
-            .readText()
-            .trim()
+        runCatching {
+            val process =
+                ProcessBuilder("git", "config", "--get", "remote.origin.url")
+                    .redirectErrorStream(true)
+                    .start()
+            process.inputStream
+                .bufferedReader()
+                .readText()
+                .trim()
+        }.getOrDefault("")
+
     val regex = Regex("""github\.com[/:](.+?)(?:\.git)?$""")
-    return regex.find(url)?.groupValues?.get(1) ?: "unknown/unknown"
+    regex.find(url)?.groupValues?.get(1) ?: run {
+        logger.warn(
+            "Could not determine the GitHub repository from git remote 'origin'. " +
+                "The in-app update check and repository link will be inactive. " +
+                "Set -PgithubRepoName=owner/repo to override.",
+        )
+        "unknown/unknown"
+    }
 }
 
 buildConfig {
@@ -275,11 +309,6 @@ buildConfig {
         "JSPECIFY_VERSION",
         provider { libs.versions.jspecify.get() },
     )
-    buildConfigField(
-        "GITHUB_REPO_NAME",
-        provider {
-            getGitRepoName()
-        },
-    )
-    buildConfigField("GITHUB_REPO_URL", provider { "https://github.com/${getGitRepoName()}" })
+    buildConfigField("GITHUB_REPO_NAME", provider { githubRepoName })
+    buildConfigField("GITHUB_REPO_URL", provider { "https://github.com/$githubRepoName" })
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
-    implementation(libs.okhttp)
+    // Exposed on the public API: RequestModule.createHttpClient() returns an OkHttpClient.
+    api(libs.okhttp)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,9 @@ vineflower = "1.12.0"
 jadx = "1.5.6"
 slf4j = "2.0.18"
 picocli = "4.7.7"
+javafx = "21.0.4"
+junit = "5.12.2"
+junitPlatform = "1.12.2"
 
 # annotations referenced by decompiled sources, only used to generate the base project.
 # these are the newest known versions; older ones are pinned per release date in the registry
@@ -29,10 +32,17 @@ reconstruct-common = { module = "io.github.lxgaming:reconstruct-common", version
 vineflower = { module = "org.vineflower:vineflower", version.ref = "vineflower" }
 jadx-core = { module = "io.github.skylot:jadx-core", version.ref = "jadx" }
 jadx-java-input = { module = "io.github.skylot:jadx-java-input", version.ref = "jadx" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
+
+# Not consumed as dependencies: the generated Gradle project declares these itself, pinned per
+# Minecraft release date in AnnotationLibraryRegistry. The entries exist so Renovate knows the
+# coordinates and keeps the newest-known version in [versions] current.
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 

--- a/launchermeta/build.gradle.kts
+++ b/launchermeta/build.gradle.kts
@@ -1,4 +1,7 @@
 dependencies {
+    // Exposed on the public API: LauncherMeta's constructor takes an OkHttpClient.
+    api(libs.okhttp)
+
     implementation(libs.jackson.databind)
-    implementation(libs.okhttp)
+    implementation(libs.slf4j.api)
 }

--- a/launchermeta/src/main/java/de/timmi6790/launchermeta/LauncherMeta.java
+++ b/launchermeta/src/main/java/de/timmi6790/launchermeta/LauncherMeta.java
@@ -19,12 +19,16 @@ import java.net.URL;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.jetbrains.annotations.Nullable;
 
+@Slf4j
 public class LauncherMeta {
     private static final String VERSION_MANIFEST_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
 
@@ -61,7 +65,10 @@ public class LauncherMeta {
 
         final List<Version> versions = new ArrayList<>();
         for (final JsonNode item : root.path("versions")) {
-            versions.add(this.mapVersion(item));
+            final Version version = this.mapVersion(item);
+            if (version != null) {
+                versions.add(version);
+            }
         }
 
         return new VersionManifest(latestRecord, versions);
@@ -75,17 +82,29 @@ public class LauncherMeta {
         return new ReleaseManifest(downloads, root.path("mainClass").asText(null), libraries, javaVersion, version);
     }
 
-    private Version mapVersion(final JsonNode node) throws MalformedURLException {
+    /**
+     * Maps a single manifest entry.
+     *
+     * @param node the entry to map
+     * @return the version, or {@code null} when its type is not recognised
+     * @throws MalformedURLException if the entry carries an unusable URL
+     */
+    @Nullable private Version mapVersion(final JsonNode node) throws MalformedURLException {
+        final String id = node.path("id").asText();
+        final String rawType = node.path("type").asText();
+
+        final Optional<VersionType> type = VersionType.fromId(rawType);
+        if (type.isEmpty()) {
+            // Skipped rather than fatal: an unrecognised type must not cost us the whole manifest.
+            log.warn("Skipping version {} with unrecognised type '{}'.", id, rawType);
+            return null;
+        }
+
         return new Version(
-                node.path("id").asText(),
-                this.parseVersionType(node.path("type").asText()),
+                id,
+                type.get(),
                 this.toUrl(node.path("url").asText()),
                 OffsetDateTime.parse(node.path("releaseTime").asText()));
-    }
-
-    private VersionType parseVersionType(final String typeName) {
-        final String normalized = typeName.replace('-', '_').toUpperCase();
-        return VersionType.valueOf(normalized);
     }
 
     private Downloads mapDownloads(final JsonNode downloadsNode) throws MalformedURLException {

--- a/launchermeta/src/main/java/de/timmi6790/launchermeta/data/release/Library.java
+++ b/launchermeta/src/main/java/de/timmi6790/launchermeta/data/release/Library.java
@@ -1,9 +1,3 @@
 package de.timmi6790.launchermeta.data.release;
 
-import java.util.Optional;
-
-public record Library(String name, LibraryArtifact artifact) {
-    public Optional<LibraryArtifact> getArtifact() {
-        return Optional.ofNullable(this.artifact);
-    }
-}
+public record Library(String name, LibraryArtifact artifact) {}

--- a/launchermeta/src/main/java/de/timmi6790/launchermeta/data/release/ReleaseManifest.java
+++ b/launchermeta/src/main/java/de/timmi6790/launchermeta/data/release/ReleaseManifest.java
@@ -3,43 +3,5 @@ package de.timmi6790.launchermeta.data.release;
 import de.timmi6790.launchermeta.data.version.Version;
 import java.util.List;
 
-public class ReleaseManifest {
-    private final Downloads downloads;
-    private final String mainClass;
-    private final List<Library> libraries;
-    private final JavaVersion javaVersion;
-    private final Version version;
-
-    public ReleaseManifest(
-            final Downloads downloads,
-            final String mainClass,
-            final List<Library> libraries,
-            final JavaVersion javaVersion,
-            final Version version) {
-        this.downloads = downloads;
-        this.mainClass = mainClass;
-        this.libraries = libraries;
-        this.javaVersion = javaVersion;
-        this.version = version;
-    }
-
-    public Downloads getDownloads() {
-        return this.downloads;
-    }
-
-    public String getMainClass() {
-        return this.mainClass;
-    }
-
-    public List<Library> getLibraries() {
-        return this.libraries;
-    }
-
-    public JavaVersion getJavaVersion() {
-        return this.javaVersion;
-    }
-
-    public Version getVersion() {
-        return this.version;
-    }
-}
+public record ReleaseManifest(
+        Downloads downloads, String mainClass, List<Library> libraries, JavaVersion javaVersion, Version version) {}

--- a/launchermeta/src/main/java/de/timmi6790/launchermeta/data/version/VersionType.java
+++ b/launchermeta/src/main/java/de/timmi6790/launchermeta/data/version/VersionType.java
@@ -1,8 +1,35 @@
 package de.timmi6790.launchermeta.data.version;
 
+import java.util.Locale;
+import java.util.Optional;
+
 public enum VersionType {
     RELEASE,
     SNAPSHOT,
     OLD_BETA,
-    OLD_ALPHA
+    OLD_ALPHA;
+
+    /**
+     * Resolves the manifest's textual version type.
+     *
+     * <p>Returns empty rather than throwing for values this enum does not know. Mojang controls the
+     * manifest and has added types before; propagating an exception here would fail the whole version
+     * list over a single unrecognised entry.
+     *
+     * @param id type name as it appears in the manifest
+     * @return the matching type, or empty when unrecognised
+     */
+    public static Optional<VersionType> fromId(final String id) {
+        if (id == null || id.isBlank()) {
+            return Optional.empty();
+        }
+
+        final String normalized = id.trim().replace('-', '_').toUpperCase(Locale.ENGLISH);
+        for (final VersionType type : values()) {
+            if (type.name().equals(normalized)) {
+                return Optional.of(type);
+            }
+        }
+        return Optional.empty();
+    }
 }

--- a/launchermeta/src/test/java/de/timmi6790/launchermeta/data/version/VersionTypeTest.java
+++ b/launchermeta/src/test/java/de/timmi6790/launchermeta/data/version/VersionTypeTest.java
@@ -1,0 +1,68 @@
+package de.timmi6790.launchermeta.data.version;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class VersionTypeTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "release, RELEASE",
+        "snapshot, SNAPSHOT",
+        "old_beta, OLD_BETA",
+        "old-beta, OLD_BETA",
+        "old_alpha, OLD_ALPHA",
+        "old-alpha, OLD_ALPHA",
+        "RELEASE, RELEASE",
+        "  release  , RELEASE",
+    })
+    @DisplayName("maps the manifest spelling to the matching constant")
+    void mapsManifestSpelling(final String id, final VersionType expected) {
+        assertEquals(expected, VersionType.fromId(id).orElseThrow());
+    }
+
+    @ParameterizedTest
+    @EnumSource(VersionType.class)
+    @DisplayName("every constant round-trips through its own name")
+    void everyConstantRoundTrips(final VersionType type) {
+        assertEquals(type, VersionType.fromId(type.name()).orElseThrow());
+        assertEquals(
+                type,
+                VersionType.fromId(type.name().toLowerCase(Locale.ENGLISH)).orElseThrow());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   ", "experimental", "april_fools", "old_gamma"})
+    @DisplayName("returns empty for a type it does not know instead of throwing")
+    void returnsEmptyForUnknownType(final String id) {
+        assertTrue(VersionType.fromId(id).isEmpty());
+    }
+
+    @Test
+    @DisplayName("returns empty for null")
+    void returnsEmptyForNull() {
+        assertTrue(VersionType.fromId(null).isEmpty());
+    }
+
+    @Test
+    @DisplayName("is unaffected by the default locale")
+    void isLocaleIndependent() {
+        final Locale original = Locale.getDefault();
+        try {
+            // Turkish uppercases 'i' to a dotted capital, which a locale-sensitive fold would break on.
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+            assertEquals(VersionType.RELEASE, VersionType.fromId("release").orElseThrow());
+            assertEquals(VersionType.SNAPSHOT, VersionType.fromId("snapshot").orElseThrow());
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/McDeobCommand.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/McDeobCommand.java
@@ -145,16 +145,6 @@ public class McDeobCommand implements Callable<Integer> {
             shouldRemap = false;
         }
 
-        if (this.gradleProject && !this.decompile) {
-            log.error("--gradle-project requires --decompile");
-            return 1;
-        }
-
-        if (this.gradleProject && !this.libraries) {
-            log.error("--gradle-project requires --libraries");
-            return 1;
-        }
-
         final ProcessorOptions processorOptions = ProcessorOptions.builder()
                 .remap(shouldRemap)
                 .decompile(this.decompile)
@@ -163,6 +153,12 @@ public class McDeobCommand implements Callable<Integer> {
                 .setupGradleProject(this.gradleProject)
                 .decompilerType(decompilerType)
                 .build();
+
+        final Optional<String> conflict = processorOptions.validate();
+        if (conflict.isPresent()) {
+            log.error("{} Pass --decompile and --libraries alongside --gradle-project.", conflict.get());
+            return 1;
+        }
 
         return Processor.runProcessor(request, processorOptions, null) ? 0 : 1;
     }

--- a/src/main/java/com/shanebeestudios/mcdeop/VersionManager.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/VersionManager.java
@@ -5,6 +5,7 @@ import de.timmi6790.launchermeta.data.release.ReleaseManifest;
 import de.timmi6790.launchermeta.data.version.Version;
 import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -44,10 +45,15 @@ public class VersionManager {
 
     private List<Version> fetchVersions() {
         try {
-            return this.launcherMeta.getVersionManifest().versions().stream()
-                    .filter(this::isSupportedVersion)
-                    .sorted(Comparator.comparing(Version::releaseTime).reversed())
-                    .toList();
+            final List<Version> supported = new ArrayList<>();
+            for (final Version version : this.launcherMeta.getVersionManifest().versions()) {
+                if (this.isSupportedVersion(version)) {
+                    supported.add(version);
+                }
+            }
+
+            supported.sort(Comparator.comparing(Version::releaseTime).reversed());
+            return List.copyOf(supported);
         } catch (final IOException e) {
             log.error("Failed to fetch version manifest", e);
             return List.of();

--- a/src/main/java/com/shanebeestudios/mcdeop/app/McDeobFxApp.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/app/McDeobFxApp.java
@@ -10,20 +10,14 @@ import com.shanebeestudios.mcdeop.app.components.McDeobUpdateNotification;
 import com.shanebeestudios.mcdeop.app.components.McDeobVersionSelection;
 import com.shanebeestudios.mcdeop.processor.Processor;
 import com.shanebeestudios.mcdeop.processor.ResourceRequest;
+import com.shanebeestudios.mcdeop.util.DesktopLauncher;
 import com.shanebeestudios.mcdeop.util.GeneratedConstant;
-import com.shanebeestudios.mcdeop.util.GithubReleaseChecker;
-import com.shanebeestudios.mcdeop.util.Util;
 import de.timmi6790.launchermeta.data.release.ReleaseManifest;
 import de.timmi6790.launchermeta.data.version.Version;
-import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
 import javafx.animation.FadeTransition;
 import javafx.animation.TranslateTransition;
 import javafx.application.Application;
@@ -45,18 +39,22 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.util.Duration;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
 
 @Slf4j
 public class McDeobFxApp extends Application {
-    private static final String GITHUB_RELEASES_URL = GeneratedConstant.GITHUB_REPO_URL + "/releases/latest";
-    private static final DateTimeFormatter CHECKED_AT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-    @Setter
+    /**
+     * Handed over from {@code main} before the toolkit starts.
+     *
+     * <p>Static because {@link Application#launch} constructs the application reflectively through a
+     * no-argument constructor, leaving no place to pass a dependency in. Assigned once, before launch,
+     * and only read afterwards.
+     */
     private static VersionManager versionManager;
 
-    private final GithubReleaseChecker releaseChecker = new GithubReleaseChecker();
+    @Nullable private Task<Void> runningTask;
 
     private McDeobTypeSelection typeSelection;
     private McDeobVersionSelection versionSelection;
@@ -64,12 +62,10 @@ public class McDeobFxApp extends Application {
     private McDeobStatusBox statusBox;
     private McDeobUpdateNotification updateNotification;
     private McDeobLogWindow logWindow;
+    private UpdateCheckController updateCheckController;
     private Button startButton;
     private Button openDirectoryButton;
-    private Button checkUpdatesButton;
     private Path lastOutputDirectory;
-    private String latestReleaseUrl = GITHUB_RELEASES_URL;
-    private boolean updateCheckInProgress;
 
     @Override
     public void start(final Stage stage) {
@@ -88,14 +84,15 @@ public class McDeobFxApp extends Application {
         root.setFillWidth(true);
         root.getStyleClass().add("app-shell");
 
+        // Built before the header, which wires its refresh button to the notification banner.
+        this.updateNotification = new McDeobUpdateNotification();
+
         final McDeobTitle title = new McDeobTitle();
         final HBox iconActions = this.createIconActions();
         final HBox headerRow = new HBox(12, title, iconActions);
         headerRow.setAlignment(Pos.TOP_LEFT);
         headerRow.getStyleClass().add("header-row");
         HBox.setHgrow(title, Priority.ALWAYS);
-
-        this.updateNotification = new McDeobUpdateNotification();
 
         this.typeSelection = new McDeobTypeSelection();
         this.typeSelection.addSelectionListener(() -> {
@@ -178,23 +175,36 @@ public class McDeobFxApp extends Application {
         root.prefWidthProperty().bind(appScroll.widthProperty().subtract(20));
 
         final Scene scene = new Scene(appScroll, 900, 680);
-        try {
-            scene.getStylesheets()
-                    .add(Objects.requireNonNull(this.getClass().getResource("/styles.css"))
-                            .toExternalForm());
-        } catch (final Exception e) {
-            log.warn("Could not load styles.css", e);
+        final URL stylesheet = this.getClass().getResource("/styles.css");
+        if (stylesheet != null) {
+            scene.getStylesheets().add(stylesheet.toExternalForm());
+        } else {
+            log.warn("Could not load styles.css; the interface will fall back to default styling.");
         }
 
         stage.setScene(scene);
         this.configureStageSize(stage, scene, root, headerRow, controlsCard, statusRow, startRow, logCard);
         stage.show();
         this.animateEntrance(headerRow, controlsCard, statusRow, startRow, logCard);
-        this.checkForUpdatesAsync(false);
+        this.updateCheckController.check(false);
+    }
+
+    /**
+     * Installs the version manager for the application instance the toolkit is about to create.
+     *
+     * @param versionManager the manager to use, must be set before {@link Application#launch}
+     */
+    public static void setVersionManager(final VersionManager versionManager) {
+        McDeobFxApp.versionManager = versionManager;
     }
 
     @Override
     public void stop() {
+        // The processing thread is a daemon, so it cannot keep the JVM alive on its own; cancelling
+        // gives the task a chance to stop rather than being killed mid-write on shutdown.
+        if (this.runningTask != null) {
+            this.runningTask.cancel(true);
+        }
         if (this.logWindow != null) {
             this.logWindow.dispose();
         }
@@ -227,15 +237,24 @@ public class McDeobFxApp extends Application {
         return row;
     }
 
+    /**
+     * Builds the header icon buttons and the update check they drive.
+     *
+     * @return the icon button row
+     */
     private HBox createIconActions() {
         final Button githubButton = this.createIconButton("\u2197");
         githubButton.setOnAction(e -> this.getHostServices().showDocument(GeneratedConstant.GITHUB_REPO_URL));
 
-        this.checkUpdatesButton = this.createIconButton("\u21BB");
-        this.checkUpdatesButton.getStyleClass().add("update-icon-button");
-        this.checkUpdatesButton.setOnAction(e -> this.checkForUpdatesAsync(true));
+        final Button checkUpdatesButton = this.createIconButton("\u21BB");
+        checkUpdatesButton.getStyleClass().add("update-icon-button");
 
-        final HBox iconActions = new HBox(8, githubButton, this.checkUpdatesButton);
+        this.updateCheckController =
+                new UpdateCheckController(this.updateNotification, checkUpdatesButton, url -> this.getHostServices()
+                        .showDocument(url));
+        checkUpdatesButton.setOnAction(e -> this.updateCheckController.check(true));
+
+        final HBox iconActions = new HBox(8, githubButton, checkUpdatesButton);
         iconActions.setAlignment(Pos.CENTER_RIGHT);
         iconActions.getStyleClass().add("icon-actions");
         return iconActions;
@@ -249,96 +268,6 @@ public class McDeobFxApp extends Application {
         button.setPrefSize(34, 34);
         button.setMaxSize(34, 34);
         return button;
-    }
-
-    private void checkForUpdatesAsync(final boolean userInitiated) {
-        if (this.updateCheckInProgress) {
-            return;
-        }
-        this.updateCheckInProgress = true;
-        this.checkUpdatesButton.setDisable(true);
-        this.updateNotification.showChecking();
-
-        final Task<GithubReleaseChecker.UpdateCheckResult> task = new Task<>() {
-            @Override
-            protected GithubReleaseChecker.UpdateCheckResult call() {
-                try {
-                    return McDeobFxApp.this.releaseChecker.checkForUpdateDetailed(GeneratedConstant.VERSION);
-                } catch (final Exception e) {
-                    log.error("Could not check for newer GitHub releases", e);
-                    return new GithubReleaseChecker.UpdateCheckResult(
-                            GithubReleaseChecker.UpdateCheckStatus.FAILED,
-                            null,
-                            e.getMessage() != null
-                                    ? e.getMessage()
-                                    : e.getClass().getSimpleName());
-                }
-            }
-        };
-
-        task.setOnSucceeded(event -> {
-            this.updateCheckInProgress = false;
-            this.checkUpdatesButton.setDisable(false);
-            final GithubReleaseChecker.UpdateCheckResult result = task.getValue();
-            if (result == null) {
-                this.updateNotification.showCheckFailed(
-                        "No response received from update checker.",
-                        () -> this.checkForUpdatesAsync(true),
-                        this.updateNotification::dismiss);
-                return;
-            }
-
-            if (result.status() == GithubReleaseChecker.UpdateCheckStatus.UPDATE_AVAILABLE
-                    && result.updateInfo() != null) {
-                final String url = result.updateInfo().releaseUrl();
-                if (url != null && !url.isBlank()) {
-                    this.latestReleaseUrl = url;
-                }
-                this.updateNotification.showUpdateAvailable(
-                        GeneratedConstant.VERSION,
-                        result.updateInfo(),
-                        this::openLatestRelease,
-                        this.updateNotification::dismiss);
-                return;
-            }
-
-            if (result.status() == GithubReleaseChecker.UpdateCheckStatus.UP_TO_DATE) {
-                if (userInitiated) {
-                    final String checkedAt = "Last checked: " + CHECKED_AT_FORMAT.format(LocalDateTime.now());
-                    this.updateNotification.showUpToDate(
-                            GeneratedConstant.VERSION, checkedAt, () -> this.checkForUpdatesAsync(true));
-                } else {
-                    this.updateNotification.dismiss();
-                }
-                return;
-            }
-
-            final String reason =
-                    result.errorMessage() != null && !result.errorMessage().isBlank()
-                            ? result.errorMessage()
-                            : "Unknown error while contacting GitHub.";
-            this.updateNotification.showCheckFailed(
-                    reason, () -> this.checkForUpdatesAsync(true), this.updateNotification::dismiss);
-        });
-
-        task.setOnFailed(event -> {
-            this.updateCheckInProgress = false;
-            this.checkUpdatesButton.setDisable(false);
-            final Throwable throwable = task.getException();
-            final String reason = throwable != null && throwable.getMessage() != null
-                    ? throwable.getMessage()
-                    : "Unexpected failure while checking updates.";
-            this.updateNotification.showCheckFailed(
-                    reason, () -> this.checkForUpdatesAsync(true), this.updateNotification::dismiss);
-        });
-
-        final Thread thread = new Thread(task, "Release-Check-Thread");
-        thread.setDaemon(true);
-        thread.start();
-    }
-
-    private void openLatestRelease() {
-        this.getHostServices().showDocument(this.latestReleaseUrl);
     }
 
     private void animateEntrance(final Node... nodes) {
@@ -434,24 +363,35 @@ public class McDeobFxApp extends Application {
             }
         };
 
+        // messageProperty already delivers changes on the FX thread, so no further dispatch is needed.
         task.messageProperty().addListener((obs, old, newMsg) -> {
             if (newMsg != null && !newMsg.isBlank()) {
-                Platform.runLater(() -> this.statusBox.updateRunningMessage(newMsg));
+                this.statusBox.updateRunningMessage(newMsg);
             }
         });
 
         task.setOnSucceeded(e -> {
+            this.runningTask = null;
             this.statusBox.updateStatus("Completed successfully!", false);
             this.openDirectoryButton.setDisable(false);
             this.resetControls();
         });
 
         task.setOnFailed(e -> {
+            this.runningTask = null;
             this.statusBox.updateStatus("Process failed. Review logs for details.", true);
             this.resetControls();
         });
 
-        new Thread(task, "Processor-Thread").start();
+        task.setOnCancelled(e -> {
+            this.runningTask = null;
+            this.resetControls();
+        });
+
+        this.runningTask = task;
+        final Thread thread = new Thread(task, "Processor-Thread");
+        thread.setDaemon(true);
+        thread.start();
     }
 
     private void setControlsEnabled(final boolean enabled) {
@@ -469,9 +409,7 @@ public class McDeobFxApp extends Application {
     }
 
     private Path resolveOutputDirectory(final Version version) {
-        final String versionFolder = String.format(
-                "%s-%s", this.typeSelection.getSelectedType().name().toLowerCase(Locale.ENGLISH), version.id());
-        return Util.getBaseDataFolder().resolve(versionFolder).toAbsolutePath();
+        return Processor.resolveOutputDirectory(this.typeSelection.getSelectedType(), version);
     }
 
     private void openOutputDirectory() {
@@ -489,27 +427,14 @@ public class McDeobFxApp extends Application {
     }
 
     private boolean tryOpenDirectory(final Path directory) {
-        final String osName = System.getProperty("os.name", "").toLowerCase(Locale.ENGLISH);
-        final List<String> command;
-        if (osName.contains("win")) {
-            command = List.of("explorer.exe", directory.toString());
-        } else if (osName.contains("mac")) {
-            command = List.of("open", directory.toString());
-        } else {
-            command = List.of("xdg-open", directory.toString());
-        }
-
-        try {
-            new ProcessBuilder(command).start();
+        if (DesktopLauncher.openDirectory(directory)) {
             return true;
-        } catch (final IOException exception) {
-            log.warn("Failed to open output directory using command {}", command, exception);
         }
 
         try {
             this.getHostServices().showDocument(directory.toUri().toString());
             return true;
-        } catch (final Exception exception) {
+        } catch (final RuntimeException exception) {
             log.error("Failed to open output directory {}", directory, exception);
             return false;
         }

--- a/src/main/java/com/shanebeestudios/mcdeop/app/UpdateCheckController.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/app/UpdateCheckController.java
@@ -1,0 +1,149 @@
+package com.shanebeestudios.mcdeop.app;
+
+import com.shanebeestudios.mcdeop.app.components.McDeobUpdateNotification;
+import com.shanebeestudios.mcdeop.util.GeneratedConstant;
+import com.shanebeestudios.mcdeop.util.GithubReleaseChecker;
+import com.shanebeestudios.mcdeop.util.GithubReleaseChecker.UpdateCheckResult;
+import com.shanebeestudios.mcdeop.util.GithubReleaseChecker.UpdateCheckStatus;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.function.Consumer;
+import javafx.concurrent.Task;
+import javafx.scene.control.Button;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Drives the release check and the notification banner it feeds.
+ *
+ * <p>Split out of the application class, which otherwise owned the scene graph, the processing run,
+ * and this flow at once.
+ */
+@Slf4j
+final class UpdateCheckController {
+    private static final String GITHUB_RELEASES_URL = GeneratedConstant.GITHUB_REPO_URL + "/releases/latest";
+    private static final DateTimeFormatter CHECKED_AT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final GithubReleaseChecker releaseChecker = new GithubReleaseChecker();
+    private final McDeobUpdateNotification notification;
+    private final Button triggerButton;
+    private final Consumer<String> releaseOpener;
+
+    private String latestReleaseUrl = GITHUB_RELEASES_URL;
+    private boolean checkInProgress;
+
+    /**
+     * @param notification banner to report progress and results through
+     * @param triggerButton button disabled while a check is running
+     * @param releaseOpener opens a release page in the user's browser
+     */
+    UpdateCheckController(
+            final McDeobUpdateNotification notification,
+            final Button triggerButton,
+            final Consumer<String> releaseOpener) {
+        this.notification = notification;
+        this.triggerButton = triggerButton;
+        this.releaseOpener = releaseOpener;
+    }
+
+    /**
+     * Starts a check unless one is already running.
+     *
+     * @param userInitiated whether the user asked for this check; an automatic check stays silent when
+     *     the app is already up to date, rather than reporting a result nobody asked for
+     */
+    void check(final boolean userInitiated) {
+        if (this.checkInProgress) {
+            return;
+        }
+        this.checkInProgress = true;
+        this.triggerButton.setDisable(true);
+        this.notification.showChecking();
+
+        final Task<UpdateCheckResult> task = new Task<>() {
+            @Override
+            protected UpdateCheckResult call() {
+                try {
+                    return UpdateCheckController.this.releaseChecker.checkForUpdateDetailed(GeneratedConstant.VERSION);
+                } catch (final Exception e) {
+                    log.error("Could not check for newer GitHub releases", e);
+                    return new UpdateCheckResult(
+                            UpdateCheckStatus.FAILED,
+                            null,
+                            e.getMessage() != null
+                                    ? e.getMessage()
+                                    : e.getClass().getSimpleName());
+                }
+            }
+        };
+
+        task.setOnSucceeded(event -> this.onResult(task.getValue(), userInitiated));
+        task.setOnFailed(event -> {
+            final Throwable throwable = task.getException();
+            final String reason = throwable != null && throwable.getMessage() != null
+                    ? throwable.getMessage()
+                    : "Unexpected failure while checking updates.";
+            this.finish();
+            this.reportFailure(reason);
+        });
+
+        final Thread thread = new Thread(task, "Release-Check-Thread");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private void onResult(final UpdateCheckResult result, final boolean userInitiated) {
+        this.finish();
+
+        if (result == null) {
+            this.reportFailure("No response received from update checker.");
+            return;
+        }
+
+        switch (result.status()) {
+            case UPDATE_AVAILABLE -> this.reportUpdateAvailable(result);
+            case UP_TO_DATE -> this.reportUpToDate(userInitiated);
+            case FAILED ->
+                this.reportFailure(
+                        result.errorMessage() != null && !result.errorMessage().isBlank()
+                                ? result.errorMessage()
+                                : "Unknown error while contacting GitHub.");
+        }
+    }
+
+    private void reportUpdateAvailable(final UpdateCheckResult result) {
+        if (result.updateInfo() == null) {
+            this.reportFailure("Update reported without any details.");
+            return;
+        }
+
+        final String url = result.updateInfo().releaseUrl();
+        if (url != null && !url.isBlank()) {
+            this.latestReleaseUrl = url;
+        }
+        this.notification.showUpdateAvailable(
+                GeneratedConstant.VERSION,
+                result.updateInfo(),
+                () -> this.releaseOpener.accept(this.latestReleaseUrl),
+                this.notification::dismiss);
+    }
+
+    private void reportUpToDate(final boolean userInitiated) {
+        if (!userInitiated) {
+            // Nothing to say about a background check that found nothing.
+            this.notification.dismiss();
+            return;
+        }
+
+        final String checkedAt = "Last checked: " + CHECKED_AT_FORMAT.format(LocalDateTime.now());
+        this.notification.showUpToDate(GeneratedConstant.VERSION, checkedAt, () -> this.check(true));
+    }
+
+    private void reportFailure(final String reason) {
+        this.notification.showCheckFailed(reason, () -> this.check(true), this.notification::dismiss);
+    }
+
+    private void finish() {
+        this.checkInProgress = false;
+        this.triggerButton.setDisable(false);
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/app/components/McDeobOptionsPanel.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/app/components/McDeobOptionsPanel.java
@@ -19,6 +19,9 @@ public class McDeobOptionsPanel extends FlowPane {
     private final CheckBox librariesCheckBox;
     private final CheckBox gradleProjectCheckBox;
 
+    /** The user's last explicit remap choice, restored when the option becomes available again. */
+    private boolean remapPreference = true;
+
     public McDeobOptionsPanel() {
         super(10, 10);
         this.setAlignment(Pos.CENTER_LEFT);
@@ -98,10 +101,24 @@ public class McDeobOptionsPanel extends FlowPane {
         this.decompilerComboBox.setDisable(!this.decompileCheckBox.isSelected());
     }
 
+    /**
+     * Shows or hides the remap option depending on whether the selected version has mappings.
+     *
+     * <p>The user's own choice is remembered across changes rather than overwritten. Hiding the
+     * option previously re-selected it on every version or target switch, silently undoing a
+     * deliberate opt-out.
+     *
+     * @param visible whether mappings are available for the selected version
+     */
     public void setRemapVisible(final boolean visible) {
+        if (this.remapCheckBox.isVisible()) {
+            this.remapPreference = this.remapCheckBox.isSelected();
+        }
+
         this.remapCheckBox.setVisible(visible);
         this.remapCheckBox.setManaged(visible);
-        this.remapCheckBox.setSelected(visible);
+        // Without mappings there is nothing to remap, so the option cannot stay selected while hidden.
+        this.remapCheckBox.setSelected(visible && this.remapPreference);
     }
 
     public ProcessorOptions getOptions() {

--- a/src/main/java/com/shanebeestudios/mcdeop/app/components/McDeobTypeSelection.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/app/components/McDeobTypeSelection.java
@@ -8,6 +8,7 @@ import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.HBox;
 
 public class McDeobTypeSelection extends HBox {
+    private final ToggleGroup typeGroup = new ToggleGroup();
     private final RadioButton clientRadio;
     private final RadioButton serverRadio;
 
@@ -16,30 +17,36 @@ public class McDeobTypeSelection extends HBox {
         this.setAlignment(Pos.CENTER_LEFT);
         this.getStyleClass().add("segmented-group");
 
-        final ToggleGroup typeGroup = new ToggleGroup();
-        this.clientRadio = new RadioButton("Client Jar");
-        this.clientRadio.setToggleGroup(typeGroup);
+        this.clientRadio = this.createOption("Client Jar");
         this.clientRadio.setSelected(true);
-        this.clientRadio.setAlignment(Pos.CENTER);
-        this.clientRadio.setContentDisplay(ContentDisplay.TEXT_ONLY);
-        this.clientRadio.getStyleClass().add("segmented-option");
-
-        this.serverRadio = new RadioButton("Server Jar");
-        this.serverRadio.setToggleGroup(typeGroup);
-        this.serverRadio.setAlignment(Pos.CENTER);
-        this.serverRadio.setContentDisplay(ContentDisplay.TEXT_ONLY);
-        this.serverRadio.getStyleClass().add("segmented-option");
+        this.serverRadio = this.createOption("Server Jar");
 
         this.getChildren().addAll(this.clientRadio, this.serverRadio);
+    }
+
+    private RadioButton createOption(final String label) {
+        final RadioButton radio = new RadioButton(label);
+        radio.setToggleGroup(this.typeGroup);
+        radio.setAlignment(Pos.CENTER);
+        radio.setContentDisplay(ContentDisplay.TEXT_ONLY);
+        radio.getStyleClass().add("segmented-option");
+        return radio;
     }
 
     public SourceType getSelectedType() {
         return this.serverRadio.isSelected() ? SourceType.SERVER : SourceType.CLIENT;
     }
 
+    /**
+     * Registers a listener notified once per selection change.
+     *
+     * <p>Bound to the toggle group rather than to each radio's {@code selectedProperty}: switching
+     * option flips two properties, so per-radio listeners fired twice for a single user action.
+     *
+     * @param runnable invoked after the selected type changes
+     */
     public void addSelectionListener(final Runnable runnable) {
-        this.clientRadio.selectedProperty().addListener((obs, oldValue, newValue) -> runnable.run());
-        this.serverRadio.selectedProperty().addListener((obs, oldValue, newValue) -> runnable.run());
+        this.typeGroup.selectedToggleProperty().addListener((obs, oldToggle, newToggle) -> runnable.run());
     }
 
     public void setControlsDisable(final boolean disable) {

--- a/src/main/java/com/shanebeestudios/mcdeop/app/components/McDeobVersionSelection.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/app/components/McDeobVersionSelection.java
@@ -5,8 +5,9 @@ import de.timmi6790.launchermeta.data.version.Version;
 import java.time.Month;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -85,11 +86,12 @@ public class McDeobVersionSelection extends ComboBox<Version> {
     }
 
     private List<DisplayVersionType> getAvailableVersionTypes() {
-        return this.allVersions.stream()
-                .map(McDeobVersionSelection::resolveDisplayType)
-                .distinct()
-                .sorted(Comparator.comparingInt(Enum::ordinal))
-                .toList();
+        // EnumSet iterates in declaration order, which is the display order these are declared in.
+        final EnumSet<DisplayVersionType> present = EnumSet.noneOf(DisplayVersionType.class);
+        for (final Version version : this.allVersions) {
+            present.add(resolveDisplayType(version));
+        }
+        return List.copyOf(present);
     }
 
     private void updateVersionTypeSelection(final DisplayVersionType versionType, final boolean selected) {
@@ -103,9 +105,12 @@ public class McDeobVersionSelection extends ComboBox<Version> {
 
     private void refreshVisibleVersions() {
         final Version currentVersion = this.getValue();
-        final List<Version> filteredVersions = this.allVersions.stream()
-                .filter(version -> this.selectedVersionTypes.contains(resolveDisplayType(version)))
-                .toList();
+        final List<Version> filteredVersions = new ArrayList<>();
+        for (final Version version : this.allVersions) {
+            if (this.selectedVersionTypes.contains(resolveDisplayType(version))) {
+                filteredVersions.add(version);
+            }
+        }
 
         this.getItems().setAll(filteredVersions);
 

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/Cleanup.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/Cleanup.java
@@ -1,7 +1,0 @@
-package com.shanebeestudios.mcdeop.processor;
-
-public interface Cleanup {
-    default void cleanup() {
-        // Custom cleanup logic
-    }
-}

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/GradleProjectWriter.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/GradleProjectWriter.java
@@ -62,11 +62,11 @@ final class GradleProjectWriter {
 
         dependencies {
         {{compileOnlyDependencies}}    implementation(fileTree("../libraries") {
-                include("**/*.jar")
-                exclude("**/*-natives-*.jar")
+                include("{{allJarsGlob}}")
+                exclude("{{nativesGlob}}")
             })
             runtimeOnly(fileTree("../libraries") {
-                include("**/*-natives-*.jar")
+                include("{{nativesGlob}}")
             })
         }
 
@@ -180,7 +180,11 @@ final class GradleProjectWriter {
                 Map.entry("mainClass", mainClass.map(this::escapeKotlinString).orElse("")),
                 Map.entry("mainClassRaw", mainClass.orElse("n/a")),
                 Map.entry("compileOnlyDependencies", this.renderCompileOnlyDependencies(dependencies.coordinates())),
-                Map.entry("unresolvedPackages", this.renderUnresolvedPackages(dependencies.unresolvedPackages())));
+                Map.entry("unresolvedPackages", this.renderUnresolvedPackages(dependencies.unresolvedPackages())),
+                // Sourced from LibraryJars so the generated build script splits natives from
+                // compile-visible jars exactly the way the package index does.
+                Map.entry("allJarsGlob", LibraryJars.ALL_JARS_GLOB),
+                Map.entry("nativesGlob", LibraryJars.NATIVES_GLOB));
 
         final Set<String> sections = new HashSet<>();
         if (mainClass.isPresent()) {

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/LibraryJars.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/LibraryJars.java
@@ -1,0 +1,42 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import java.nio.file.Path;
+import java.util.Locale;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Shared rules for classifying downloaded library jars.
+ *
+ * <p>The split between compile-visible jars and platform natives is applied in three places: when
+ * handing libraries to the decompiler, when indexing which packages the libraries provide, and in the
+ * dependency block of the generated Gradle project. Keeping the rule and the glob in one place stops
+ * those from drifting apart.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LibraryJars {
+    static final String JAR_SUFFIX = ".jar";
+
+    /**
+     * Marks platform natives, which belong on the runtime classpath only. They carry no classes worth
+     * compiling against and would otherwise pollute the package index.
+     */
+    static final String NATIVES_MARKER = "-natives-";
+
+    /** Ant-style glob matching {@link #NATIVES_MARKER}, for the generated build script. */
+    static final String NATIVES_GLOB = "**/*-natives-*.jar";
+
+    /** Ant-style glob matching every jar, for the generated build script. */
+    static final String ALL_JARS_GLOB = "**/*.jar";
+
+    /**
+     * Whether a file is a library jar that belongs on the compile classpath.
+     *
+     * @param file candidate file
+     * @return {@code true} for jars that are not platform natives
+     */
+    static boolean isCompileVisible(final Path file) {
+        final String fileName = file.getFileName().toString().toLowerCase(Locale.ENGLISH);
+        return fileName.endsWith(JAR_SUFFIX) && !fileName.contains(NATIVES_MARKER);
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/LibraryPackageIndex.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/LibraryPackageIndex.java
@@ -8,11 +8,11 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indexes the packages provided by the downloaded Minecraft libraries.
@@ -23,14 +23,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 final class LibraryPackageIndex {
 
-    private static final String JAR_SUFFIX = ".jar";
     private static final String CLASS_SUFFIX = ".class";
 
     /**
-     * Marks platform natives, which the generated project puts on the runtime classpath only. They
-     * are excluded here so the index reflects what is actually visible at compile time.
+     * Prefix of the versioned entries in a multi-release jar. Their package is the part after the
+     * version directory, so the prefix is stripped rather than being read as part of the name.
+     *
+     * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/jar/jar.html">JAR spec</a>
      */
-    private static final String NATIVES_MARKER = "-natives-";
+    private static final String MULTI_RELEASE_PREFIX = "META-INF/versions/";
+
+    /** Carries no package of its own and would otherwise index as the default package. */
+    private static final String MODULE_INFO = "module-info.class";
 
     /**
      * Indexes every compile-visible library jar below the given directory.
@@ -48,7 +52,7 @@ final class LibraryPackageIndex {
         Files.walkFileTree(root, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes) {
-                if (isCompileVisibleJar(file)) {
+                if (LibraryJars.isCompileVisible(file)) {
                     indexJar(file, packages);
                 }
                 return FileVisitResult.CONTINUE;
@@ -56,17 +60,6 @@ final class LibraryPackageIndex {
         });
 
         return packages;
-    }
-
-    /**
-     * Checks whether a file is a library jar that ends up on the compile classpath.
-     *
-     * @param file candidate file
-     * @return {@code true} for non-natives jars
-     */
-    private static boolean isCompileVisibleJar(final Path file) {
-        final String fileName = file.getFileName().toString().toLowerCase(Locale.ENGLISH);
-        return fileName.endsWith(JAR_SUFFIX) && !fileName.contains(NATIVES_MARKER);
     }
 
     /**
@@ -88,18 +81,46 @@ final class LibraryPackageIndex {
                     continue;
                 }
 
-                final String name = entry.getName();
-                if (!name.endsWith(CLASS_SUFFIX)) {
-                    continue;
-                }
-
-                final int lastSeparator = name.lastIndexOf('/');
-                if (lastSeparator > 0) {
-                    target.add(name.substring(0, lastSeparator).replace('/', '.'));
+                final String packageName = packageOf(entry.getName());
+                if (packageName != null) {
+                    target.add(packageName);
                 }
             }
         } catch (final IOException exception) {
             log.warn("Failed to index library jar {}; its packages may be reported as unresolved.", file, exception);
         }
+    }
+
+    /**
+     * Derives the package a class entry belongs to.
+     *
+     * <p>Versioned entries of a multi-release jar are rebased onto their real package. Reading the
+     * raw entry name instead would index {@code META-INF/versions/9/com/example/Foo.class} as package
+     * {@code META-INF.versions.9.com.example}, leaving the actual package unindexed and its imports
+     * reported as unresolved.
+     *
+     * @param entryName name of the archive entry
+     * @return the package name, or {@code null} for entries that declare none
+     */
+    @Nullable private static String packageOf(final String entryName) {
+        if (!entryName.endsWith(CLASS_SUFFIX)) {
+            return null;
+        }
+
+        String name = entryName;
+        if (name.startsWith(MULTI_RELEASE_PREFIX)) {
+            final int versionEnd = name.indexOf('/', MULTI_RELEASE_PREFIX.length());
+            if (versionEnd < 0) {
+                return null;
+            }
+            name = name.substring(versionEnd + 1);
+        }
+
+        if (name.equals(MODULE_INFO)) {
+            return null;
+        }
+
+        final int lastSeparator = name.lastIndexOf('/');
+        return lastSeparator > 0 ? name.substring(0, lastSeparator).replace('/', '.') : null;
     }
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/Processor.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/Processor.java
@@ -1,18 +1,19 @@
 package com.shanebeestudios.mcdeop.processor;
 
 import com.shanebeestudios.mcdeop.processor.decompiler.Decompiler;
-import com.shanebeestudios.mcdeop.processor.decompiler.DecompilerType;
 import com.shanebeestudios.mcdeop.processor.remapper.ReconstructRemapper;
 import com.shanebeestudios.mcdeop.processor.remapper.Remapper;
 import com.shanebeestudios.mcdeop.util.DurationTracker;
 import com.shanebeestudios.mcdeop.util.FileUtil;
 import com.shanebeestudios.mcdeop.util.Util;
 import de.timmi6790.RequestModule;
+import de.timmi6790.launchermeta.data.version.Version;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import lombok.extern.slf4j.Slf4j;
@@ -39,9 +40,7 @@ public class Processor {
         this.options = options;
 
         this.remapper = new ReconstructRemapper();
-        this.decompiler = Optional.ofNullable(this.options.decompilerType())
-                .orElse(DecompilerType.VINEFLOWER)
-                .createDecompiler();
+        this.decompiler = options.decompilerTypeOrDefault().createDecompiler();
 
         this.paths = ProcessorPaths.create(request);
         this.statusReporter = new ProcessorStatusReporter(responseConsumer);
@@ -49,6 +48,19 @@ public class Processor {
         final OkHttpClient httpClient = RequestModule.createHttpClient();
         this.downloadService = new ProcessorDownloadService(request, httpClient, this.paths, this.statusReporter);
         this.gradleProjectWriter = new GradleProjectWriter(request, this.paths);
+    }
+
+    /**
+     * Resolves the directory a run for this target and version reads from and writes to.
+     *
+     * <p>Exposed so callers can point the user at the output without having to reproduce the layout.
+     *
+     * @param type the target being processed
+     * @param version the Minecraft version being processed
+     * @return the absolute output directory, which need not exist yet
+     */
+    public static Path resolveOutputDirectory(final SourceType type, final Version version) {
+        return ProcessorPaths.resolveDataFolder(type, version).toAbsolutePath();
     }
 
     public static boolean runProcessor(
@@ -64,7 +76,7 @@ public class Processor {
             log.error("Failed to run processor", e);
             return false;
         } finally {
-            Util.forceGC();
+            Util.suggestGC();
         }
     }
 
@@ -83,18 +95,12 @@ public class Processor {
     }
 
     private boolean validateOptions() {
-        if (this.options.setupGradleProject() && !this.options.decompile()) {
-            log.error("Gradle project setup requires decompile to be enabled.");
-            this.statusReporter.send("Gradle setup requires decompile to be enabled.");
+        final Optional<String> conflict = this.options.validate();
+        if (conflict.isPresent()) {
+            log.error(conflict.get());
+            this.statusReporter.send(conflict.get());
             return false;
         }
-
-        if (this.options.setupGradleProject() && !this.options.downloadLibraries()) {
-            log.error("Gradle project setup requires downloading libraries.");
-            this.statusReporter.send("Gradle setup requires library downloads.");
-            return false;
-        }
-
         return true;
     }
 
@@ -187,8 +193,7 @@ public class Processor {
                 this.statusReporter.send("Downloading JAR...");
             }
 
-            java.util.concurrent.CompletableFuture.allOf(
-                            this.downloadService.downloadJar(), this.downloadService.downloadMappings())
+            CompletableFuture.allOf(this.downloadService.downloadJar(), this.downloadService.downloadMappings())
                     .join();
 
             if (this.options.downloadLibraries()) {
@@ -224,11 +229,7 @@ public class Processor {
     }
 
     public void cleanup() {
-        if (this.remapper instanceof final Cleanup cleanup) {
-            cleanup.cleanup();
-        }
-        if (this.decompiler instanceof final Cleanup cleanup) {
-            cleanup.cleanup();
-        }
+        this.remapper.cleanup();
+        this.decompiler.cleanup();
     }
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorDownloadService.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorDownloadService.java
@@ -1,22 +1,28 @@
 package com.shanebeestudios.mcdeop.processor;
 
 import com.shanebeestudios.mcdeop.processor.decompiler.Decompiler;
+import com.shanebeestudios.mcdeop.util.Checksums;
 import com.shanebeestudios.mcdeop.util.DurationTracker;
 import com.shanebeestudios.mcdeop.util.FileUtil;
+import de.timmi6790.launchermeta.data.release.DownloadInfo;
 import de.timmi6790.launchermeta.data.release.LibraryArtifact;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okio.BufferedSink;
 import okio.Okio;
 import org.jetbrains.annotations.Nullable;
@@ -40,47 +46,44 @@ final class ProcessorDownloadService {
     }
 
     @Nullable URL getJarUrl() {
-        return this.request.getJar().orElse(null);
+        return this.request.getJar().map(DownloadInfo::url).orElse(null);
     }
 
     @Nullable URL getMappingsUrl() {
-        return this.request.getMappings().orElse(null);
+        return this.request.getMappings().map(DownloadInfo::url).orElse(null);
     }
 
     CompletableFuture<Void> downloadJar() {
-        final URL jarUrl = this.request
+        final DownloadInfo jar = this.request
                 .getJar()
                 .orElseThrow(() -> new IllegalStateException("Jar URL should be validated before download."));
-        return CompletableFuture.supplyAsync(() -> {
-            try {
-                this.downloadFile(jarUrl, this.paths.jarPath(), "JAR");
-            } catch (final IOException e) {
-                throw new CompletionException(e);
-            }
-            return null;
-        });
+        return this.downloadAsync(jar, this.paths.jarPath(), "JAR");
     }
 
     CompletableFuture<Void> downloadMappings() {
-        final URL mappingsUrl = this.getMappingsUrl();
-        if (mappingsUrl == null) {
-            return CompletableFuture.completedFuture(null);
-        }
+        return this.request
+                .getMappings()
+                .map(mappings -> this.downloadAsync(mappings, this.paths.mappingsPath(), "mappings"))
+                .orElseGet(() -> CompletableFuture.completedFuture(null));
+    }
 
-        return CompletableFuture.supplyAsync(() -> {
+    private CompletableFuture<Void> downloadAsync(final DownloadInfo download, final Path path, final String fileType) {
+        return CompletableFuture.runAsync(() -> {
             try {
-                this.downloadFile(mappingsUrl, this.paths.mappingsPath(), "mappings");
+                this.downloadFile(download.url(), path, fileType, download.sha1(), download.size());
             } catch (final IOException exception) {
                 throw new CompletionException(exception);
             }
-            return null;
         });
     }
 
     void downloadLibraries() throws IOException {
-        final List<LibraryArtifact> libraries = this.request.getLibraries().stream()
-                .filter(library -> library.path() != null && library.url() != null)
-                .toList();
+        final List<LibraryArtifact> libraries = new ArrayList<>();
+        for (final LibraryArtifact library : this.request.getLibraries()) {
+            if (library.path() != null && library.url() != null) {
+                libraries.add(library);
+            }
+        }
 
         if (libraries.isEmpty()) {
             log.warn("No downloadable library artifacts were found for this version.");
@@ -94,7 +97,7 @@ final class ProcessorDownloadService {
             for (int i = 0; i < libraries.size(); i++) {
                 final LibraryArtifact library = libraries.get(i);
                 final Path outputPath = this.paths.librariesPath().resolve(library.path());
-                this.downloadFile(library.url(), outputPath, "library");
+                this.downloadFile(library.url(), outputPath, "library", library.sha1(), library.size());
 
                 final int downloaded = i + 1;
                 if (downloaded == libraries.size() || downloaded % 25 == 0) {
@@ -132,38 +135,65 @@ final class ProcessorDownloadService {
     }
 
     private List<Path> getDownloadedLibraryJars() throws IOException {
+        final List<Path> libraries = new ArrayList<>();
         if (!Files.isDirectory(this.paths.librariesPath())) {
-            return List.of();
+            return libraries;
         }
 
-        try (Stream<Path> files = Files.walk(this.paths.librariesPath())) {
-            return files.filter(Files::isRegularFile)
-                    .filter(this::isLibraryJar)
-                    .sorted()
-                    .toList();
+        Files.walkFileTree(this.paths.librariesPath(), new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes) {
+                if (LibraryJars.isCompileVisible(file)) {
+                    libraries.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        // Sorted so the classpath handed to the decompiler is stable between runs.
+        Collections.sort(libraries);
+        return libraries;
+    }
+
+    /**
+     * Downloads a file unless a verified copy is already present.
+     *
+     * <p>The size and SHA-1 from the manifest are checked before any request is made, so an intact
+     * file skips the network entirely, and again after writing, so a truncated or corrupted transfer
+     * fails loudly rather than being handed to the remapper.
+     *
+     * @param url source to download from
+     * @param path destination to write to
+     * @param fileType label used in progress logging
+     * @param expectedSha1 digest from the manifest, or {@code null} when not advertised
+     * @param expectedSize size from the manifest, or a non-positive value when not advertised
+     * @throws IOException if the transfer fails or the result does not match the manifest
+     */
+    private void downloadFile(
+            final URL url,
+            final Path path,
+            final String fileType,
+            @Nullable final String expectedSha1,
+            final long expectedSize)
+            throws IOException {
+        if (Checksums.matches(path, expectedSha1, expectedSize)) {
+            log.info("Already have a verified {}, skipping download.", path.getFileName());
+            return;
         }
-    }
 
-    private boolean isLibraryJar(final Path path) {
-        final String fileName = path.getFileName().toString().toLowerCase(Locale.ENGLISH);
-        return fileName.endsWith(".jar") && !fileName.contains("-natives-");
-    }
-
-    private void downloadFile(final URL url, final Path path, final String fileType) throws IOException {
         try (final DurationTracker ignored = new DurationTracker(
                 duration -> log.info("Successfully downloaded {} file in {}!", fileType, duration))) {
             log.info("Downloading {} file from Mojang...", fileType);
             final Request httpRequest = new Request.Builder().url(url).build();
 
             try (final Response response = this.httpClient.newCall(httpRequest).execute()) {
-                if (response.body() == null) {
-                    throw new IOException("Response body was null");
+                if (!response.isSuccessful()) {
+                    throw new IOException("Download of " + url + " failed with HTTP " + response.code());
                 }
 
-                final long length = response.body().contentLength();
-                if (Files.exists(path) && Files.size(path) == length) {
-                    log.info("Already have {}, skipping download.", path.getFileName());
-                    return;
+                final ResponseBody body = response.body();
+                if (body == null) {
+                    throw new IOException("Response body was null");
                 }
 
                 FileUtil.remove(path);
@@ -171,10 +201,40 @@ final class ProcessorDownloadService {
                 if (parent != null) {
                     Files.createDirectories(parent);
                 }
-                try (BufferedSink sink = Okio.buffer(Okio.sink(path))) {
-                    sink.writeAll(response.body().source());
+                try (final BufferedSink sink = Okio.buffer(Okio.sink(path))) {
+                    sink.writeAll(body.source());
                 }
             }
         }
+
+        this.verifyDownload(path, expectedSha1);
+    }
+
+    /**
+     * Verifies a freshly written file against the manifest, deleting it if it does not match.
+     *
+     * <p>A mismatched file is removed rather than left in place, so the next run downloads it again
+     * instead of treating the corrupt copy as a cache hit.
+     *
+     * @param path file that was just written
+     * @param expectedSha1 digest from the manifest, or {@code null} when not advertised
+     * @throws IOException if the file cannot be read or does not match
+     */
+    private void verifyDownload(final Path path, @Nullable final String expectedSha1) throws IOException {
+        if (expectedSha1 == null || expectedSha1.isBlank()) {
+            log.debug("No SHA-1 advertised for {}, skipping verification.", path.getFileName());
+            return;
+        }
+
+        final String actualSha1 = Checksums.sha1(path);
+        if (actualSha1.equalsIgnoreCase(expectedSha1.trim())) {
+            return;
+        }
+
+        FileUtil.remove(path);
+        throw new IOException(String.format(
+                "Checksum mismatch for %s: expected SHA-1 %s but got %s. The download was corrupted and has been"
+                        + " discarded.",
+                path.getFileName(), Checksums.describe(expectedSha1), actualSha1));
     }
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorOptions.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorOptions.java
@@ -1,6 +1,7 @@
 package com.shanebeestudios.mcdeop.processor;
 
 import com.shanebeestudios.mcdeop.processor.decompiler.DecompilerType;
+import java.util.Optional;
 import lombok.Builder;
 
 @Builder
@@ -10,4 +11,30 @@ public record ProcessorOptions(
         boolean zipDecompileOutput,
         boolean downloadLibraries,
         boolean setupGradleProject,
-        DecompilerType decompilerType) {}
+        DecompilerType decompilerType) {
+
+    /**
+     * Checks that the selected steps can run together.
+     *
+     * <p>Owned by the options rather than by each caller: the command line and the processor each
+     * enforced these rules separately, with their own wording, and nothing kept the two in step.
+     *
+     * @return a description of the first conflict found, or empty when the combination is valid
+     */
+    public Optional<String> validate() {
+        if (this.setupGradleProject && !this.decompile) {
+            return Optional.of("Gradle project setup requires decompilation to be enabled.");
+        }
+        if (this.setupGradleProject && !this.downloadLibraries) {
+            return Optional.of("Gradle project setup requires library downloads to be enabled.");
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * @return the selected decompiler, falling back to the default when none was chosen
+     */
+    public DecompilerType decompilerTypeOrDefault() {
+        return this.decompilerType == null ? DecompilerType.VINEFLOWER : this.decompilerType;
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorPaths.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/ProcessorPaths.java
@@ -1,6 +1,7 @@
 package com.shanebeestudios.mcdeop.processor;
 
 import com.shanebeestudios.mcdeop.util.Util;
+import de.timmi6790.launchermeta.data.version.Version;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,12 +18,24 @@ record ProcessorPaths(
         Path librariesPath,
         Path gradleProjectPath) {
 
+    /**
+     * Resolves the output directory for a target and version.
+     *
+     * <p>Public so the UI can point the user at the output without recomputing the layout. It used to
+     * duplicate this format, which meant a change here silently sent the "open output folder" action
+     * to a directory that does not exist.
+     *
+     * @param type the target being processed
+     * @param version the Minecraft version being processed
+     * @return the directory this run reads from and writes to
+     */
+    static Path resolveDataFolder(final SourceType type, final Version version) {
+        final String versionFolder = String.format("%s-%s", type.name().toLowerCase(Locale.ENGLISH), version.id());
+        return Util.getBaseDataFolder().resolve(versionFolder);
+    }
+
     static ProcessorPaths create(final ResourceRequest request) {
-        final String versionFolder = String.format(
-                "%s-%s",
-                request.type().name().toLowerCase(Locale.ENGLISH),
-                request.getVersion().id());
-        final Path dataFolderPath = Util.getBaseDataFolder().resolve(versionFolder);
+        final Path dataFolderPath = resolveDataFolder(request.type(), request.getVersion());
         try {
             Files.createDirectories(dataFolderPath);
         } catch (final IOException exception) {

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/ResourceRequest.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/ResourceRequest.java
@@ -7,46 +7,57 @@ import de.timmi6790.launchermeta.data.release.Library;
 import de.timmi6790.launchermeta.data.release.LibraryArtifact;
 import de.timmi6790.launchermeta.data.release.ReleaseManifest;
 import de.timmi6790.launchermeta.data.version.Version;
-import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 public record ResourceRequest(ReleaseManifest manifest, SourceType type) {
     public Version getVersion() {
-        return this.manifest.getVersion();
+        return this.manifest.version();
     }
 
-    public Optional<URL> getJar() {
-        final Downloads downloads = this.manifest.getDownloads();
+    /**
+     * The jar download for the selected target.
+     *
+     * <p>Returns the full {@link DownloadInfo} rather than only its URL so the advertised size and
+     * SHA-1 digest stay available for verification after the download.
+     *
+     * @return the jar download, or empty when the manifest does not list one
+     */
+    public Optional<DownloadInfo> getJar() {
+        final Downloads downloads = this.manifest.downloads();
         return Optional.ofNullable(
-                        switch (this.type) {
-                            case SERVER -> downloads.server();
-                            case CLIENT -> downloads.client();
-                        })
-                .map(DownloadInfo::url);
+                switch (this.type) {
+                    case SERVER -> downloads.server();
+                    case CLIENT -> downloads.client();
+                });
     }
 
-    public Optional<URL> getMappings() {
-        final Downloads downloads = this.manifest.getDownloads();
+    public Optional<DownloadInfo> getMappings() {
+        final Downloads downloads = this.manifest.downloads();
         return switch (this.type) {
-            case SERVER -> downloads.getServerMappings().map(DownloadInfo::url);
-            case CLIENT -> downloads.getClientMappings().map(DownloadInfo::url);
+            case SERVER -> downloads.getServerMappings();
+            case CLIENT -> downloads.getClientMappings();
         };
     }
 
     public List<LibraryArtifact> getLibraries() {
-        return this.manifest.getLibraries().stream()
-                .map(Library::getArtifact)
-                .flatMap(Optional::stream)
-                .toList();
+        final List<LibraryArtifact> artifacts = new ArrayList<>();
+        for (final Library library : this.manifest.libraries()) {
+            final LibraryArtifact artifact = library.artifact();
+            if (artifact != null) {
+                artifacts.add(artifact);
+            }
+        }
+        return artifacts;
     }
 
     public Optional<String> getMainClass() {
-        return Optional.ofNullable(this.manifest.getMainClass()).filter(mainClass -> !mainClass.isBlank());
+        return Optional.ofNullable(this.manifest.mainClass()).filter(mainClass -> !mainClass.isBlank());
     }
 
     public Optional<Integer> getJavaVersion() {
-        return Optional.ofNullable(this.manifest.getJavaVersion())
+        return Optional.ofNullable(this.manifest.javaVersion())
                 .map(JavaVersion::majorVersion)
                 .filter(version -> version > 0);
     }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/SimpleTemplateEngine.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/SimpleTemplateEngine.java
@@ -1,19 +1,31 @@
 package com.shanebeestudios.mcdeop.processor;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+/**
+ * Minimal Mustache-style renderer for the generated project files.
+ *
+ * <p>Supports {@code {{value}}} substitution and {@code {{#section}}...{{/section}}} blocks, which is
+ * everything the templates here need.
+ */
 final class SimpleTemplateEngine {
+
+    private static final Pattern SECTION_PATTERN = Pattern.compile("\\{\\{#([a-zA-Z0-9_-]+)}}");
+
     String render(final String template, final Map<String, String> values, final Set<String> enabledSections) {
         String rendered = template;
-        for (final String section : enabledSections) {
-            rendered = rendered.replace("{{#" + section + "}}", "");
-            rendered = rendered.replace("{{/" + section + "}}", "");
-        }
 
-        for (final String section : this.findSections(rendered)) {
-            if (!enabledSections.contains(section)) {
-                rendered = rendered.replaceAll("(?s)\\{\\{#" + section + "}}.*?\\{\\{/" + section + "}}", "");
+        // Disabled sections are dropped wholesale; enabled ones keep their body and lose the markers.
+        for (final String section : findSections(rendered)) {
+            if (enabledSections.contains(section)) {
+                rendered = rendered.replace("{{#" + section + "}}", "");
+                rendered = rendered.replace("{{/" + section + "}}", "");
+            } else {
+                rendered = sectionBlockPattern(section).matcher(rendered).replaceAll("");
             }
         }
 
@@ -24,10 +36,20 @@ final class SimpleTemplateEngine {
         return rendered;
     }
 
-    private Set<String> findSections(final String input) {
-        final java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("\\{\\{#([a-zA-Z0-9_-]+)}}");
-        final java.util.regex.Matcher matcher = pattern.matcher(input);
-        final java.util.Set<String> sections = new java.util.HashSet<>();
+    /**
+     * Builds a pattern matching a whole section block, opening and closing markers included.
+     *
+     * @param section the section name, quoted so it cannot act as a pattern of its own
+     * @return the compiled block pattern
+     */
+    private static Pattern sectionBlockPattern(final String section) {
+        final String quoted = Pattern.quote(section);
+        return Pattern.compile("(?s)\\{\\{#" + quoted + "}}.*?\\{\\{/" + quoted + "}}");
+    }
+
+    private static Set<String> findSections(final String input) {
+        final Matcher matcher = SECTION_PATTERN.matcher(input);
+        final Set<String> sections = new HashSet<>();
         while (matcher.find()) {
             sections.add(matcher.group(1));
         }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/ConsoleEngineDecompiler.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/ConsoleEngineDecompiler.java
@@ -1,0 +1,55 @@
+package com.shanebeestudios.mcdeop.processor.decompiler;
+
+import com.shanebeestudios.mcdeop.util.NativeImageUtil;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
+
+/**
+ * Base for the backends driven by Vineflower's {@link ConsoleDecompiler} entry point.
+ *
+ * <p>Vineflower and the Fernflower compatibility profile differ only in the options they pass, so the
+ * argument assembly and the runtime-scan decision live here rather than being duplicated per engine.
+ */
+abstract class ConsoleEngineDecompiler implements Decompiler {
+
+    /**
+     * Engine options to pass ahead of the input and output paths.
+     *
+     * @return the options for this engine, in the order they should be passed
+     */
+    protected abstract List<String> engineOptions();
+
+    /**
+     * Letting the decompiler read the JDK's type hierarchy removes redundant casts and restores
+     * {@code @Override} annotations, but the runtime scan needs the {@code jrt} filesystem provider
+     * that native images do not ship.
+     *
+     * @return the {@code --include-runtime} option appropriate for this runtime
+     */
+    private static String includeRuntimeOption() {
+        return NativeImageUtil.isNativeImage() ? "--include-runtime=0" : "--include-runtime=1";
+    }
+
+    @Override
+    public void decompile(final Path jarPath, final Path outputDir, final List<Path> libraries) {
+        final List<String> options = this.engineOptions();
+        final List<String> args = new ArrayList<>(options.size() + libraries.size() + 3);
+
+        args.addAll(options);
+        args.add(includeRuntimeOption());
+        for (final Path library : libraries) {
+            args.add("--add-external=" + library.toAbsolutePath());
+        }
+        args.add(jarPath.toAbsolutePath().toString());
+        args.add(outputDir.toAbsolutePath().toString());
+
+        ConsoleDecompiler.main(args.toArray(String[]::new));
+    }
+
+    @Override
+    public boolean supportsExternalLibraries() {
+        return true;
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/Decompiler.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/Decompiler.java
@@ -4,13 +4,23 @@ import java.nio.file.Path;
 import java.util.List;
 
 public interface Decompiler {
-    void decompile(Path jarPath, Path outputDir);
+    /**
+     * Decompiles a jar into source files.
+     *
+     * @param jarPath jar to decompile
+     * @param outputDir directory to write the sources to
+     * @param libraries jars to resolve references against, empty when none are available or the
+     *     backend does not {@linkplain #supportsExternalLibraries() support them}
+     */
+    void decompile(Path jarPath, Path outputDir, List<Path> libraries);
 
-    default void decompile(final Path jarPath, final Path outputDir, final List<Path> libraries) {
-        this.decompile(jarPath, outputDir);
-    }
-
+    /** Whether {@link #decompile} makes use of the libraries it is given. */
     default boolean supportsExternalLibraries() {
         return false;
+    }
+
+    /** Releases whatever the backend holds onto after a run. Backends without state need not override. */
+    default void cleanup() {
+        // No cleanup required by default.
     }
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/DecompilerType.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/DecompilerType.java
@@ -1,7 +1,6 @@
 package com.shanebeestudios.mcdeop.processor.decompiler;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -10,6 +9,16 @@ public enum DecompilerType {
     VINEFLOWER("vineflower", "Vineflower"),
     FERNFLOWER("fernflower", "Fernflower"),
     JADX("jadx", "JADX");
+
+    /**
+     * The values {@link #fromValue(String)} accepts.
+     *
+     * <p>Derived from the constants rather than written out, so the command line help cannot come to
+     * advertise an engine that does not exist.
+     */
+    private static final List<String> CLI_VALUES = buildCliValues();
+
+    private static final String SUPPORTED_VALUES = String.join(", ", CLI_VALUES);
 
     private final String cliValue;
     private final String displayName;
@@ -37,29 +46,32 @@ public enum DecompilerType {
         }
 
         final String normalized = value.trim().toLowerCase(Locale.ENGLISH);
-        return Arrays.stream(values())
-                .filter(type -> type.cliValue.equals(normalized) || type.name().equalsIgnoreCase(normalized))
-                .findFirst();
+        for (final DecompilerType type : values()) {
+            if (type.cliValue.equals(normalized)
+                    || type.name().toLowerCase(Locale.ENGLISH).equals(normalized)) {
+                return Optional.of(type);
+            }
+        }
+        return Optional.empty();
     }
 
     public static String supportedValues() {
-        return String.join(", ", cliValues());
+        return SUPPORTED_VALUES;
     }
 
     /**
-     * The values {@link #fromValue(String)} accepts.
-     *
-     * <p>Derived from the constants rather than written out, so the command line help cannot come to
-     * advertise an engine that does not exist.
-     *
      * @return every supported CLI value, in declaration order
      */
     public static List<String> cliValues() {
+        return CLI_VALUES;
+    }
+
+    private static List<String> buildCliValues() {
         final List<String> values = new ArrayList<>(values().length);
         for (final DecompilerType type : values()) {
             values.add(type.cliValue);
         }
-        return values;
+        return List.copyOf(values);
     }
 
     @Override

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/FernflowerDecompiler.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/FernflowerDecompiler.java
@@ -1,40 +1,11 @@
 package com.shanebeestudios.mcdeop.processor.decompiler;
 
-import com.shanebeestudios.mcdeop.util.NativeImageUtil;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
-import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
 
-public class FernflowerDecompiler implements Decompiler {
-    /**
-     * Reading the JDK's type hierarchy yields better output, but the runtime scan needs the {@code jrt} filesystem
-     * provider that native images do not ship.
-     */
-    private static String includeRuntimeOption() {
-        return NativeImageUtil.isNativeImage() ? "--include-runtime=0" : "--include-runtime=1";
-    }
-
+/** The legacy Fernflower-style profile, which is the engine's behaviour with no options applied. */
+public class FernflowerDecompiler extends ConsoleEngineDecompiler {
     @Override
-    public void decompile(final Path jarPath, final Path outputDir) {
-        this.decompile(jarPath, outputDir, List.of());
-    }
-
-    @Override
-    public void decompile(final Path jarPath, final Path outputDir, final List<Path> libraries) {
-        final List<String> args = new ArrayList<>(libraries.size() + 3);
-        args.add(includeRuntimeOption());
-        for (final Path library : libraries) {
-            args.add("--add-external=" + library.toAbsolutePath());
-        }
-        args.add(jarPath.toAbsolutePath().toString());
-        args.add(outputDir.toAbsolutePath().toString());
-
-        ConsoleDecompiler.main(args.toArray(String[]::new));
-    }
-
-    @Override
-    public boolean supportsExternalLibraries() {
-        return true;
+    protected List<String> engineOptions() {
+        return List.of();
     }
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/JadxDecompiler.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/JadxDecompiler.java
@@ -2,10 +2,11 @@ package com.shanebeestudios.mcdeop.processor.decompiler;
 
 import jadx.api.JadxArgs;
 import java.nio.file.Path;
+import java.util.List;
 
 public class JadxDecompiler implements Decompiler {
     @Override
-    public void decompile(final Path jarPath, final Path outputDir) {
+    public void decompile(final Path jarPath, final Path outputDir, final List<Path> libraries) {
         final JadxArgs jadxArgs = new JadxArgs();
         jadxArgs.setInputFile(jarPath.toFile());
         jadxArgs.setOutDir(outputDir.toFile());

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/VineflowerDecompiler.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/decompiler/VineflowerDecompiler.java
@@ -1,55 +1,24 @@
 package com.shanebeestudios.mcdeop.processor.decompiler;
 
-import com.shanebeestudios.mcdeop.util.NativeImageUtil;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
-import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
 
-public class VineflowerDecompiler implements Decompiler {
+public class VineflowerDecompiler extends ConsoleEngineDecompiler {
     /**
      * Options are pinned explicitly rather than left to Vineflower's defaults because the CLI silently ignores
      * unrecognised options: a renamed or removed option produces no diagnostic, only quietly different output.
      */
-    private static final String[] DECOMPILER_OPTIONS = {
-        "--ascii-strings=1", // Escape non-ASCII literals so invisible codepoints stay visible in the source
-        "--ternary-constant-simplification=0", // Folding boolean ternary branches can emit invalid code
-        "--ternary-in-if=1", // Recovers the original loop conditions instead of goto-style break chains
-        "--verify-merges=0", // Troubleshooting-only switch; enabling it replaces real LVT names with varNN
-        "--old-try-dedup=0", // Inserts dummy exception handlers that break pattern-matching switches
-        "--pattern-matching=1", // Resugars `case Type t ->` switches over sealed hierarchies
-        "--decompile-switch-expressions=1" // Resugars the SwitchBootstraps.typeSwitch invokedynamic
-    };
-
-    /**
-     * Letting the decompiler read the JDK's type hierarchy removes redundant casts and restores {@code @Override}
-     * annotations, but the runtime scan needs the {@code jrt} filesystem provider that native images do not ship.
-     */
-    private static String includeRuntimeOption() {
-        return NativeImageUtil.isNativeImage() ? "--include-runtime=0" : "--include-runtime=1";
-    }
+    private static final List<String> DECOMPILER_OPTIONS = List.of(
+            "--ascii-strings=1", // Escape non-ASCII literals so invisible codepoints stay visible in the source
+            "--ternary-constant-simplification=0", // Folding boolean ternary branches can emit invalid code
+            "--ternary-in-if=1", // Recovers the original loop conditions instead of goto-style break chains
+            "--verify-merges=0", // Troubleshooting-only switch; enabling it replaces real LVT names with varNN
+            "--old-try-dedup=0", // Inserts dummy exception handlers that break pattern-matching switches
+            "--pattern-matching=1", // Resugars `case Type t ->` switches over sealed hierarchies
+            "--decompile-switch-expressions=1" // Resugars the SwitchBootstraps.typeSwitch invokedynamic
+            );
 
     @Override
-    public void decompile(final Path jarPath, final Path outputDir) {
-        this.decompile(jarPath, outputDir, List.of());
-    }
-
-    @Override
-    public void decompile(final Path jarPath, final Path outputDir, final List<Path> libraries) {
-        final List<String> args = new ArrayList<>(DECOMPILER_OPTIONS.length + libraries.size() + 3);
-        args.addAll(List.of(DECOMPILER_OPTIONS));
-        args.add(includeRuntimeOption());
-        for (final Path library : libraries) {
-            args.add("--add-external=" + library.toAbsolutePath());
-        }
-        args.add(jarPath.toAbsolutePath().toString());
-        args.add(outputDir.toAbsolutePath().toString());
-
-        ConsoleDecompiler.main(args.toArray(String[]::new));
-    }
-
-    @Override
-    public boolean supportsExternalLibraries() {
-        return true;
+    protected List<String> engineOptions() {
+        return DECOMPILER_OPTIONS;
     }
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/remapper/ReconstructRemapper.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/remapper/ReconstructRemapper.java
@@ -1,6 +1,5 @@
 package com.shanebeestudios.mcdeop.processor.remapper;
 
-import com.shanebeestudios.mcdeop.processor.Cleanup;
 import com.shanebeestudios.mcdeop.processor.ReconConfig;
 import io.github.lxgaming.reconstruct.common.Reconstruct;
 import io.github.lxgaming.reconstruct.common.manager.TransformerManager;
@@ -11,7 +10,7 @@ import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class ReconstructRemapper implements Remapper, Cleanup {
+public class ReconstructRemapper implements Remapper {
     private static final String RECON_THREADS_PROPERTY = "mcdeob.reconstruct.threads";
 
     /**
@@ -58,6 +57,11 @@ public class ReconstructRemapper implements Remapper, Cleanup {
         reconstruct.load();
     }
 
+    /**
+     * Resolves the worker count for a remap.
+     *
+     * @return the configured override when valid, otherwise one worker per available processor
+     */
     private int resolveThreads() {
         final String configuredValue = System.getProperty(RECON_THREADS_PROPERTY);
         if (configuredValue != null && !configuredValue.isBlank()) {
@@ -66,13 +70,6 @@ public class ReconstructRemapper implements Remapper, Cleanup {
             } catch (final NumberFormatException exception) {
                 log.warn("Invalid {} value '{}', using auto thread selection", RECON_THREADS_PROPERTY, configuredValue);
             }
-        }
-
-        // Work around Reconstruct task tracking deadlock in native-image worker execution.
-        if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
-            final int nativeThreads = Math.max(1, Runtime.getRuntime().availableProcessors());
-            log.info("Native runtime detected, using {} Reconstruct thread(s)", nativeThreads);
-            return nativeThreads;
         }
 
         return Math.max(1, Runtime.getRuntime().availableProcessors());

--- a/src/main/java/com/shanebeestudios/mcdeop/processor/remapper/Remapper.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/processor/remapper/Remapper.java
@@ -4,4 +4,9 @@ import java.nio.file.Path;
 
 public interface Remapper {
     void remap(Path jarPath, Path mappingsPath, Path outputDir);
+
+    /** Releases whatever the backend holds onto after a run. Backends without state need not override. */
+    default void cleanup() {
+        // No cleanup required by default.
+    }
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/util/Checksums.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/util/Checksums.java
@@ -1,0 +1,98 @@
+package com.shanebeestudios.mcdeop.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Locale;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * SHA-1 digests for verifying downloaded files against the launcher manifest.
+ *
+ * <p>SHA-1 is the algorithm Mojang publishes, so it is what can be checked against. This guards
+ * against truncated, corrupted, and partially written files; it is not a defence against a hostile
+ * server, for which SHA-1 would be too weak.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Checksums {
+    private static final String ALGORITHM = "SHA-1";
+    private static final int BUFFER_SIZE = 64 * 1024;
+
+    /**
+     * Computes the SHA-1 digest of a file.
+     *
+     * @param path file to digest
+     * @return the digest as lowercase hex
+     * @throws IOException if the file cannot be read
+     */
+    public static String sha1(final Path path) throws IOException {
+        final MessageDigest digest = newDigest();
+        final byte[] buffer = new byte[BUFFER_SIZE];
+
+        try (final InputStream input = Files.newInputStream(path);
+                final DigestInputStream digestInput = new DigestInputStream(input, digest)) {
+            while (digestInput.read(buffer) != -1) {
+                // Reading is what feeds the digest; the bytes themselves are not needed.
+            }
+        }
+
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    /**
+     * Checks an existing file against the size and digest the manifest advertises.
+     *
+     * <p>Size is compared first because it is far cheaper and rules out most mismatches without
+     * reading the file. A missing digest falls back to the size check alone, which is all the older
+     * manifests support.
+     *
+     * @param path file to check, need not exist
+     * @param expectedSha1 expected digest, or {@code null} when the manifest does not provide one
+     * @param expectedSize expected size in bytes, or a non-positive value when unknown
+     * @return {@code true} if the file is present and matches
+     */
+    public static boolean matches(final Path path, @Nullable final String expectedSha1, final long expectedSize) {
+        if (!Files.isRegularFile(path)) {
+            return false;
+        }
+
+        try {
+            if (expectedSize > 0 && Files.size(path) != expectedSize) {
+                return false;
+            }
+            if (expectedSha1 == null || expectedSha1.isBlank()) {
+                // Nothing further to verify against; the size check above is the best available.
+                return expectedSize > 0;
+            }
+            return sha1(path).equalsIgnoreCase(expectedSha1.trim());
+        } catch (final IOException exception) {
+            return false;
+        }
+    }
+
+    /**
+     * Normalises a digest for display and comparison.
+     *
+     * @param sha1 digest to normalise, may be {@code null}
+     * @return the trimmed lowercase digest, or {@code "unknown"} when absent
+     */
+    public static String describe(@Nullable final String sha1) {
+        return sha1 == null || sha1.isBlank() ? "unknown" : sha1.trim().toLowerCase(Locale.ENGLISH);
+    }
+
+    private static MessageDigest newDigest() {
+        try {
+            return MessageDigest.getInstance(ALGORITHM);
+        } catch (final NoSuchAlgorithmException exception) {
+            // Every conformant Java runtime ships SHA-1.
+            throw new IllegalStateException(ALGORITHM + " is not available", exception);
+        }
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/util/DesktopLauncher.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/util/DesktopLauncher.java
@@ -1,0 +1,45 @@
+package com.shanebeestudios.mcdeop.util;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/** Opens paths in the platform's file manager. */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DesktopLauncher {
+
+    /**
+     * Opens a directory in the platform's file manager.
+     *
+     * @param directory directory to reveal
+     * @return {@code true} if a file manager was launched
+     */
+    public static boolean openDirectory(final Path directory) {
+        final List<String> command = fileManagerCommand(directory);
+        try {
+            new ProcessBuilder(command).start();
+            return true;
+        } catch (final IOException exception) {
+            log.warn("Failed to open directory using command {}", command, exception);
+            return false;
+        }
+    }
+
+    private static List<String> fileManagerCommand(final Path directory) {
+        final String osName = System.getProperty("os.name", "").toLowerCase(Locale.ENGLISH);
+        final String target = directory.toString();
+
+        if (osName.contains("win")) {
+            return List.of("explorer.exe", target);
+        }
+        if (osName.contains("mac")) {
+            return List.of("open", target);
+        }
+        return List.of("xdg-open", target);
+    }
+}

--- a/src/main/java/com/shanebeestudios/mcdeop/util/FileUtil.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/util/FileUtil.java
@@ -1,11 +1,12 @@
 package com.shanebeestudios.mcdeop.util;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.stream.Stream;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import lombok.AccessLevel;
@@ -18,35 +19,59 @@ public class FileUtil {
             return;
         }
 
-        try (final Stream<Path> files = Files.walk(path)) {
-            files.sorted(Comparator.reverseOrder()).forEach(FileUtil::deletePath);
-        }
+        Files.walkFileTree(path, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes) throws IOException {
+                Files.deleteIfExists(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(final Path directory, final IOException failure)
+                    throws IOException {
+                if (failure != null) {
+                    throw failure;
+                }
+                Files.deleteIfExists(directory);
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 
     public static void zip(final Path sourceDirPath, final Path zipFilePath) throws IOException {
-        final Path zipFile = Files.createFile(zipFilePath);
-        try (final ZipOutputStream zs = new ZipOutputStream(Files.newOutputStream(zipFile));
-                final Stream<Path> paths = Files.walk(sourceDirPath)) {
-            for (final Iterator<Path> it = paths.iterator(); it.hasNext(); ) {
-                final Path path = it.next();
-                if (Files.isDirectory(path)) {
-                    continue;
-                }
+        final Path parent = zipFilePath.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
 
-                final ZipEntry zipEntry =
-                        new ZipEntry(sourceDirPath.relativize(path).toString());
-                zs.putNextEntry(zipEntry);
-                Files.copy(path, zs);
-                zs.closeEntry();
-            }
+        try (final OutputStream output = Files.newOutputStream(zipFilePath);
+                final ZipOutputStream zipStream = new ZipOutputStream(output)) {
+            Files.walkFileTree(sourceDirPath, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes)
+                        throws IOException {
+                    zipStream.putNextEntry(new ZipEntry(toEntryName(sourceDirPath, file)));
+                    Files.copy(file, zipStream);
+                    zipStream.closeEntry();
+                    return FileVisitResult.CONTINUE;
+                }
+            });
         }
     }
 
-    private static void deletePath(final Path path) {
-        try {
-            Files.deleteIfExists(path);
-        } catch (final IOException exception) {
-            throw new IllegalStateException("Failed to delete " + path.toAbsolutePath(), exception);
-        }
+    /**
+     * Builds the archive entry name for a file.
+     *
+     * <p>The ZIP format mandates {@code /} as the separator regardless of platform, and {@link
+     * ZipOutputStream} does not normalise it. Relying on {@link Path#toString()} alone therefore
+     * produced backslash-separated entries on Windows, which most tools unpack as a flat directory of
+     * literally-named files rather than a tree.
+     *
+     * @param sourceDirPath root the entry is relative to
+     * @param file the file being archived
+     * @return the entry name with {@code /} separators
+     */
+    private static String toEntryName(final Path sourceDirPath, final Path file) {
+        return sourceDirPath.relativize(file).toString().replace('\\', '/');
     }
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/util/GithubReleaseChecker.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/util/GithubReleaseChecker.java
@@ -1,92 +1,126 @@
 package com.shanebeestudios.mcdeop.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import de.timmi6790.RequestModule;
 import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.jetbrains.annotations.Nullable;
 
 @Slf4j
 public final class GithubReleaseChecker {
-    private static final URI LATEST_RELEASE_API =
-            URI.create("https://api.github.com/repos/" + GeneratedConstant.GITHUB_REPO_NAME + "/releases/latest");
-    private static final Pattern TAG_NAME_PATTERN = Pattern.compile("\"tag_name\"\\s*:\\s*\"([^\"]+)\"");
-    private static final Pattern HTML_URL_PATTERN = Pattern.compile("\"html_url\"\\s*:\\s*\"([^\"]+)\"");
-    private static final Pattern NAME_PATTERN = Pattern.compile("\"name\"\\s*:\\s*\"([^\"]*)\"");
-    private static final Pattern PUBLISHED_AT_PATTERN = Pattern.compile("\"published_at\"\\s*:\\s*\"([^\"]+)\"");
-    private static final Pattern BODY_PATTERN =
-            Pattern.compile("\"body\"\\s*:\\s*\"((?:\\\\.|[^\"\\\\])*)\"", Pattern.DOTALL);
+    private static final String LATEST_RELEASE_API =
+            "https://api.github.com/repos/" + GeneratedConstant.GITHUB_REPO_NAME + "/releases/latest";
+
+    /** Repository name used when the build could not determine one; the API call would 404. */
+    private static final String UNKNOWN_REPOSITORY = "unknown/unknown";
+
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
+
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper = JsonMapper.builder().build();
+
+    public GithubReleaseChecker() {
+        this(RequestModule.createHttpClient());
+    }
+
+    public GithubReleaseChecker(final OkHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
 
     /**
      * Algorithm:
      * 1) Fetch latest GitHub release JSON.
-     * 2) Extract {@code tag_name} and release URL.
+     * 2) Read {@code tag_name} and release URL.
      * 3) Parse all numeric groups from current and latest versions.
-     * 4) Compare each numeric part lexicographically (missing parts treated as 0).
+     * 4) Compare each numeric part in order (missing parts treated as 0).
      * 5) Return update info only when latest > current.
      */
-    public Optional<UpdateInfo> checkForUpdate(final String currentVersion) throws IOException, InterruptedException {
+    public Optional<UpdateInfo> checkForUpdate(final String currentVersion) throws IOException {
         final UpdateCheckResult result = this.checkForUpdateDetailed(currentVersion);
         return result.status() == UpdateCheckStatus.UPDATE_AVAILABLE
                 ? Optional.ofNullable(result.updateInfo())
                 : Optional.empty();
     }
 
-    public UpdateCheckResult checkForUpdateDetailed(final String currentVersion)
-            throws IOException, InterruptedException {
-        final HttpClient client = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(5))
-                .followRedirects(HttpClient.Redirect.NORMAL)
-                .build();
-
-        final HttpRequest request = HttpRequest.newBuilder(LATEST_RELEASE_API)
-                .header("Accept", "application/vnd.github+json")
-                .header("X-GitHub-Api-Version", "2022-11-28")
-                .header("User-Agent", "McDeob/" + currentVersion)
-                .timeout(Duration.ofSeconds(8))
-                .GET()
-                .build();
-
-        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-        if (response.statusCode() != 200) {
+    public UpdateCheckResult checkForUpdateDetailed(final String currentVersion) throws IOException {
+        if (GeneratedConstant.GITHUB_REPO_NAME.equals(UNKNOWN_REPOSITORY)) {
             return new UpdateCheckResult(
-                    UpdateCheckStatus.FAILED, null, "GitHub API returned HTTP " + response.statusCode());
+                    UpdateCheckStatus.FAILED, null, "This build does not know which repository it came from.");
         }
 
-        final String body = response.body();
-        final String latestTag = this.matchFirst(TAG_NAME_PATTERN, body);
+        final Request request = new Request.Builder()
+                .url(LATEST_RELEASE_API)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .build();
+
+        final JsonNode root;
+        try (final Response response = this.httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                return new UpdateCheckResult(
+                        UpdateCheckStatus.FAILED, null, "GitHub API returned HTTP " + response.code());
+            }
+
+            final ResponseBody body = response.body();
+            if (body == null) {
+                return new UpdateCheckResult(UpdateCheckStatus.FAILED, null, "GitHub API returned an empty response");
+            }
+            root = this.objectMapper.readTree(body.byteStream());
+        }
+
+        final String latestTag = text(root, "tag_name");
         if (latestTag == null || latestTag.isBlank()) {
             return new UpdateCheckResult(UpdateCheckStatus.FAILED, null, "Could not parse release tag from response");
         }
 
-        final String releaseUrl = this.matchFirst(HTML_URL_PATTERN, body);
-        final String releaseName = this.matchFirst(NAME_PATTERN, body);
-        final String publishedAt = this.matchFirst(PUBLISHED_AT_PATTERN, body);
-        final String releaseBodyRaw = this.matchFirst(BODY_PATTERN, body);
-        final String releaseBody = releaseBodyRaw != null ? this.unescapeJsonString(releaseBodyRaw) : null;
-        final UpdateInfo info = new UpdateInfo(latestTag, releaseUrl, releaseName, publishedAt, releaseBody);
-        if (this.isNewer(currentVersion, latestTag)) {
-            return new UpdateCheckResult(UpdateCheckStatus.UPDATE_AVAILABLE, info, null);
-        }
-        return new UpdateCheckResult(UpdateCheckStatus.UP_TO_DATE, info, null);
+        final UpdateInfo info = new UpdateInfo(
+                latestTag, text(root, "html_url"), text(root, "name"), text(root, "published_at"), text(root, "body"));
+
+        return isNewer(currentVersion, latestTag)
+                ? new UpdateCheckResult(UpdateCheckStatus.UPDATE_AVAILABLE, info, null)
+                : new UpdateCheckResult(UpdateCheckStatus.UP_TO_DATE, info, null);
     }
 
-    private String matchFirst(final Pattern pattern, final String value) {
-        final Matcher matcher = pattern.matcher(value);
-        return matcher.find() ? matcher.group(1) : null;
+    /**
+     * Reads a top-level string field.
+     *
+     * <p>Replaces the hand-written regex extraction this used to do, which depended on GitHub's field
+     * ordering to avoid matching a nested {@code name} from the assets array, and needed its own JSON
+     * string unescaper for the release body.
+     *
+     * @param root the parsed response
+     * @param field field to read
+     * @return the field value, or {@code null} when absent or not a string
+     */
+    @Nullable private static String text(final JsonNode root, final String field) {
+        final JsonNode node = root.path(field);
+        return node.isTextual() ? node.asText() : null;
     }
 
-    private boolean isNewer(final String currentVersion, final String latestVersion) {
-        final List<Integer> currentParts = this.parseVersionParts(this.normalizeVersion(currentVersion));
-        final List<Integer> latestParts = this.parseVersionParts(this.normalizeVersion(latestVersion));
+    /**
+     * Compares two version strings by their numeric parts.
+     *
+     * <p>Package-private rather than private so the ordering rules can be tested without a network
+     * round trip.
+     *
+     * @param currentVersion the running version
+     * @param latestVersion the version advertised by the release
+     * @return {@code true} when the latest version is strictly newer
+     */
+    static boolean isNewer(final String currentVersion, final String latestVersion) {
+        final List<Integer> currentParts = parseVersionParts(normalizeVersion(currentVersion));
+        final List<Integer> latestParts = parseVersionParts(normalizeVersion(latestVersion));
 
         if (currentParts.isEmpty() || latestParts.isEmpty()) {
             return false;
@@ -106,9 +140,9 @@ public final class GithubReleaseChecker {
         return false;
     }
 
-    private String normalizeVersion(final String version) {
+    private static String normalizeVersion(@Nullable final String version) {
         if (version == null || version.isEmpty()) {
-            return version;
+            return "";
         }
         if (version.startsWith("v") || version.startsWith("V")) {
             return version.substring(1);
@@ -116,68 +150,18 @@ public final class GithubReleaseChecker {
         return version;
     }
 
-    private List<Integer> parseVersionParts(final String version) {
+    private static List<Integer> parseVersionParts(final String version) {
         final List<Integer> parts = new ArrayList<>();
         final Matcher matcher = NUMBER_PATTERN.matcher(version);
         while (matcher.find()) {
-            parts.add(Integer.parseInt(matcher.group()));
+            try {
+                parts.add(Integer.parseInt(matcher.group()));
+            } catch (final NumberFormatException exception) {
+                // A run of digits too long for an int cannot be a meaningful version part.
+                log.debug("Ignoring oversized version part '{}' in '{}'", matcher.group(), version);
+            }
         }
         return parts;
-    }
-
-    private String unescapeJsonString(final String value) {
-        if (value == null) {
-            return null;
-        }
-        final StringBuilder out = new StringBuilder(value.length());
-        for (int i = 0; i < value.length(); i++) {
-            final char current = value.charAt(i);
-            if (current != '\\' || i + 1 >= value.length()) {
-                out.append(current);
-                continue;
-            }
-            final char next = value.charAt(++i);
-            switch (next) {
-                case '"':
-                case '\\':
-                case '/':
-                    out.append(next);
-                    break;
-                case 'b':
-                    out.append('\b');
-                    break;
-                case 'f':
-                    out.append('\f');
-                    break;
-                case 'n':
-                    out.append('\n');
-                    break;
-                case 'r':
-                    out.append('\r');
-                    break;
-                case 't':
-                    out.append('\t');
-                    break;
-                case 'u':
-                    if (i + 4 < value.length()) {
-                        final String hex = value.substring(i + 1, i + 5);
-                        try {
-                            out.append((char) Integer.parseInt(hex, 16));
-                            i += 4;
-                        } catch (final NumberFormatException ignored) {
-                            out.append("\\u").append(hex);
-                            i += 4;
-                        }
-                    } else {
-                        out.append("\\u");
-                    }
-                    break;
-                default:
-                    out.append(next);
-                    break;
-            }
-        }
-        return out.toString();
     }
 
     public enum UpdateCheckStatus {

--- a/src/main/java/com/shanebeestudios/mcdeop/util/JavaLogBridge.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/util/JavaLogBridge.java
@@ -10,7 +10,14 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 public final class JavaLogBridge {
-    private static final int MAX_BACKLOG_CHARS = 20_000_000;
+    /**
+     * Retained so a log window opened after startup still shows what already happened.
+     *
+     * <p>Sized a little above what the window itself keeps, which is all that can be displayed. It
+     * used to hold 20 million characters, or roughly 40 MB, retained for the life of the process and
+     * copied in full every time a listener registered.
+     */
+    private static final int MAX_BACKLOG_CHARS = 200_000;
 
     private static final List<Consumer<String>> LISTENERS = new CopyOnWriteArrayList<>();
     private static final StringBuilder BACKLOG = new StringBuilder();

--- a/src/main/java/com/shanebeestudios/mcdeop/util/Util.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/util/Util.java
@@ -1,15 +1,15 @@
 package com.shanebeestudios.mcdeop.util;
 
-import java.lang.ref.WeakReference;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Locale;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Util {
     public static boolean isRunningMacOS() {
-        return System.getProperty("os.name").contains("Mac OS");
+        return System.getProperty("os.name", "").toLowerCase(Locale.ENGLISH).contains("mac");
     }
 
     public static Path getBaseDataFolder() {
@@ -22,13 +22,14 @@ public class Util {
         return Paths.get("versions");
     }
 
-    // https://stackoverflow.com/a/6915221
-    public static void forceGC() {
-        Object obj = new Object();
-        final WeakReference<Object> ref = new WeakReference<>(obj);
-        obj = null;
-        while (ref.get() != null) {
-            System.gc();
-        }
+    /**
+     * Hints that now is a good moment to collect, after a stage that drops hundreds of megabytes.
+     *
+     * <p>Only a hint: the previous implementation spun on {@link System#gc()} until a weak reference
+     * cleared, which never terminates under {@code -XX:+DisableExplicitGC} or a no-op collector, and
+     * blocked the caller for an unbounded time under any collector.
+     */
+    public static void suggestGC() {
+        System.gc();
     }
 }

--- a/src/test/java/com/shanebeestudios/mcdeop/processor/AnnotationLibraryTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/processor/AnnotationLibraryTest.java
@@ -1,0 +1,110 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.shanebeestudios.mcdeop.processor.AnnotationLibrary.Version;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AnnotationLibraryTest {
+
+    private static final AnnotationLibrary LIBRARY = new AnnotationLibrary(
+            "org.example:annotations",
+            Set.of("org.example.annotations"),
+            true,
+            List.of(
+                    new Version(LocalDate.parse("2024-01-01"), "3.0.0"),
+                    new Version(LocalDate.parse("2022-01-01"), "2.0.0"),
+                    new Version(LocalDate.parse("2020-01-01"), "1.0.0")));
+
+    @Test
+    @DisplayName("picks the newest version that already existed at release time")
+    void picksContemporaryVersion() {
+        assertEquals("3.0.0", LIBRARY.versionFor(LocalDate.parse("2025-06-01")));
+        assertEquals("2.0.0", LIBRARY.versionFor(LocalDate.parse("2023-06-01")));
+        assertEquals("1.0.0", LIBRARY.versionFor(LocalDate.parse("2021-06-01")));
+    }
+
+    @Test
+    @DisplayName("treats a release on the publication date itself as eligible")
+    void includesTheBoundaryDate() {
+        assertEquals("2.0.0", LIBRARY.versionFor(LocalDate.parse("2022-01-01")));
+    }
+
+    @Test
+    @DisplayName("falls back to the oldest version for releases predating them all")
+    void fallsBackToOldestVersion() {
+        assertEquals("1.0.0", LIBRARY.versionFor(LocalDate.parse("2010-01-01")));
+    }
+
+    @Test
+    @DisplayName("builds a full coordinate for the release date")
+    void buildsCoordinate() {
+        assertEquals("org.example:annotations:2.0.0", LIBRARY.coordinateFor(LocalDate.parse("2023-06-01")));
+    }
+
+    @Test
+    @DisplayName("matches sub-packages only when configured to")
+    void matchesSubPackagesWhenEnabled() {
+        assertTrue(LIBRARY.provides("org.example.annotations"));
+        assertTrue(LIBRARY.provides("org.example.annotations.nested"));
+        assertFalse(LIBRARY.provides("org.example.annotationsExtra"));
+        assertFalse(LIBRARY.provides("org.other"));
+
+        final AnnotationLibrary exact = new AnnotationLibrary(
+                "org.example:exact",
+                Set.of("javax.annotation"),
+                false,
+                List.of(new Version(LocalDate.parse("2020-01-01"), "1.0.0")));
+
+        assertTrue(exact.provides("javax.annotation"));
+        assertFalse(exact.provides("javax.annotation.processing"));
+    }
+
+    @Test
+    @DisplayName("rejects a library declaring no packages or no versions")
+    void rejectsIncompleteDefinitions() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new AnnotationLibrary(
+                        "org.example:empty",
+                        Set.of(),
+                        false,
+                        List.of(new Version(LocalDate.parse("2020-01-01"), "1.0.0"))));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new AnnotationLibrary("org.example:empty", Set.of("org.example"), false, List.of()));
+    }
+
+    @Test
+    @DisplayName("the registry resolves the packages it claims and nothing else")
+    void registryResolvesKnownPackages() {
+        assertNotNull(AnnotationLibraryRegistry.findByPackage("org.jetbrains.annotations"));
+        assertNotNull(AnnotationLibraryRegistry.findByPackage("org.jetbrains.annotations.ApiStatus"));
+        assertNotNull(AnnotationLibraryRegistry.findByPackage("javax.annotation"));
+        assertNotNull(AnnotationLibraryRegistry.findByPackage("org.jspecify.annotations"));
+
+        // javax.annotation.processing belongs to the java.compiler module and must not pull in jsr305.
+        assertNull(AnnotationLibraryRegistry.findByPackage("javax.annotation.processing"));
+        assertNull(AnnotationLibraryRegistry.findByPackage("net.minecraft.core"));
+    }
+
+    @Test
+    @DisplayName("jspecify picks the package layout matching the release date")
+    void jspecifyVersionMatchesPackageLayout() {
+        final AnnotationLibrary jspecify = AnnotationLibraryRegistry.findByPackage("org.jspecify.nullness");
+        assertNotNull(jspecify);
+
+        // Before 1.0.0 the annotations lived in org.jspecify.nullness, so an old release needs an old version.
+        assertEquals("0.3.0", jspecify.versionFor(LocalDate.parse("2023-06-01")));
+    }
+}

--- a/src/test/java/com/shanebeestudios/mcdeop/processor/CompileDependencyResolverTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/processor/CompileDependencyResolverTest.java
@@ -1,0 +1,155 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.shanebeestudios.mcdeop.processor.CompileDependencyResolver.CompileDependencies;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CompileDependencyResolverTest {
+
+    private static final LocalDate RELEASE_DATE = LocalDate.parse("2024-06-01");
+
+    private final CompileDependencyResolver resolver = new CompileDependencyResolver();
+
+    @Test
+    @DisplayName("resolves a known annotation package to a Maven coordinate")
+    void resolvesKnownAnnotationLibrary(@TempDir final Path tempDir) throws IOException {
+        final Path sources = tempDir.resolve("decompiled");
+        final Path libraries = Files.createDirectories(tempDir.resolve("libraries"));
+        writeSource(
+                sources,
+                "net/minecraft/Foo.java",
+                "package net.minecraft;\n" + "import org.jetbrains.annotations.Nullable;\n" + "class Foo {}\n");
+
+        final CompileDependencies dependencies = this.resolver.resolve(sources, libraries, RELEASE_DATE);
+
+        assertTrue(
+                hasCoordinateStartingWith(dependencies, "org.jetbrains:annotations:"),
+                "expected a jetbrains annotations coordinate, got " + dependencies.coordinates());
+        assertTrue(dependencies.unresolvedPackages().isEmpty());
+    }
+
+    @Test
+    @DisplayName("does not declare a dependency for a package the libraries already provide")
+    void skipsPackagesProvidedByLibraries(@TempDir final Path tempDir) throws IOException {
+        final Path sources = tempDir.resolve("decompiled");
+        final Path libraries = Files.createDirectories(tempDir.resolve("libraries"));
+        writeSource(
+                sources,
+                "net/minecraft/Foo.java",
+                "package net.minecraft;\n" + "import com.google.common.collect.ImmutableList;\n" + "class Foo {}\n");
+        writeJar(libraries.resolve("guava.jar"), "com/google/common/collect/ImmutableList.class");
+
+        final CompileDependencies dependencies = this.resolver.resolve(sources, libraries, RELEASE_DATE);
+
+        assertTrue(dependencies.coordinates().isEmpty());
+        assertTrue(dependencies.unresolvedPackages().isEmpty());
+    }
+
+    @Test
+    @DisplayName("does not declare a dependency for the sources' own packages")
+    void skipsSelfDeclaredPackages(@TempDir final Path tempDir) throws IOException {
+        final Path sources = tempDir.resolve("decompiled");
+        final Path libraries = Files.createDirectories(tempDir.resolve("libraries"));
+        writeSource(sources, "net/minecraft/core/Holder.java", "package net.minecraft.core;\nclass Holder {}\n");
+        writeSource(
+                sources,
+                "net/minecraft/Foo.java",
+                "package net.minecraft;\n" + "import net.minecraft.core.Holder;\n" + "class Foo {}\n");
+
+        final CompileDependencies dependencies = this.resolver.resolve(sources, libraries, RELEASE_DATE);
+
+        assertTrue(dependencies.unresolvedPackages().isEmpty());
+    }
+
+    @Test
+    @DisplayName("treats JDK packages as provided without declaring anything")
+    void ignoresJdkPackages(@TempDir final Path tempDir) throws IOException {
+        final Path sources = tempDir.resolve("decompiled");
+        final Path libraries = Files.createDirectories(tempDir.resolve("libraries"));
+        writeSource(
+                sources,
+                "net/minecraft/Foo.java",
+                "package net.minecraft;\n"
+                        + "import java.util.List;\n"
+                        + "import javax.crypto.Cipher;\n"
+                        + "import javax.annotation.processing.Generated;\n"
+                        + "class Foo {}\n");
+
+        final CompileDependencies dependencies = this.resolver.resolve(sources, libraries, RELEASE_DATE);
+
+        assertTrue(dependencies.coordinates().isEmpty(), "got " + dependencies.coordinates());
+        assertTrue(dependencies.unresolvedPackages().isEmpty(), "got " + dependencies.unresolvedPackages());
+    }
+
+    @Test
+    @DisplayName("reports a package that is neither provided nor known")
+    void reportsUnknownPackage(@TempDir final Path tempDir) throws IOException {
+        final Path sources = tempDir.resolve("decompiled");
+        final Path libraries = Files.createDirectories(tempDir.resolve("libraries"));
+        writeSource(
+                sources,
+                "net/minecraft/Foo.java",
+                "package net.minecraft;\n" + "import com.example.unknown.Thing;\n" + "class Foo {}\n");
+
+        final CompileDependencies dependencies = this.resolver.resolve(sources, libraries, RELEASE_DATE);
+
+        assertTrue(dependencies.unresolvedPackages().contains("com.example.unknown"));
+        assertFalse(dependencies.unresolvedPackages().isEmpty());
+    }
+
+    @Test
+    @DisplayName("treats a jsr305 package as a dependency but not javax.annotation.processing")
+    void distinguishesJsr305FromTheCompilerModule(@TempDir final Path tempDir) throws IOException {
+        final Path sources = tempDir.resolve("decompiled");
+        final Path libraries = Files.createDirectories(tempDir.resolve("libraries"));
+        writeSource(
+                sources,
+                "net/minecraft/Foo.java",
+                "package net.minecraft;\n" + "import javax.annotation.Nonnull;\n" + "class Foo {}\n");
+
+        final CompileDependencies dependencies = this.resolver.resolve(sources, libraries, RELEASE_DATE);
+
+        assertTrue(
+                hasCoordinateStartingWith(dependencies, "com.google.code.findbugs:jsr305:"),
+                "expected a jsr305 coordinate, got " + dependencies.coordinates());
+    }
+
+    private static boolean hasCoordinateStartingWith(final CompileDependencies dependencies, final String prefix) {
+        for (final String coordinate : dependencies.coordinates()) {
+            if (coordinate.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void writeSource(final Path root, final String relativePath, final String content)
+            throws IOException {
+        final Path file = root.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+    }
+
+    private static void writeJar(final Path jar, final String... entryNames) throws IOException {
+        try (final OutputStream output = Files.newOutputStream(jar);
+                final ZipOutputStream zipStream = new ZipOutputStream(output)) {
+            for (final String entryName : entryNames) {
+                zipStream.putNextEntry(new ZipEntry(entryName));
+                zipStream.write("stub".getBytes(StandardCharsets.UTF_8));
+                zipStream.closeEntry();
+            }
+        }
+    }
+}

--- a/src/test/java/com/shanebeestudios/mcdeop/processor/DecompiledSourceScannerTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/processor/DecompiledSourceScannerTest.java
@@ -1,0 +1,139 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DecompiledSourceScannerTest {
+
+    private final DecompiledSourceScanner scanner = new DecompiledSourceScanner();
+
+    @Test
+    @DisplayName("collects imported packages and derives declared ones from the layout")
+    void collectsImportsAndDeclarations(@TempDir final Path root) throws IOException {
+        writeSource(root, "net/minecraft/Foo.java", """
+                package net.minecraft;
+
+                import org.jetbrains.annotations.Nullable;
+                import com.google.common.collect.ImmutableList;
+
+                public class Foo {}
+                """);
+
+        final DecompiledSourceScanner.ScanResult result = this.scanner.scan(root);
+
+        assertTrue(result.importedPackages().contains("org.jetbrains.annotations"));
+        assertTrue(result.importedPackages().contains("com.google.common.collect"));
+        assertTrue(result.declaredPackages().contains("net.minecraft"));
+    }
+
+    @Test
+    @DisplayName("resolves a nested type reference down to its package")
+    void resolvesNestedTypeToPackage(@TempDir final Path root) throws IOException {
+        writeSource(root, "net/minecraft/Nested.java", """
+                package net.minecraft;
+
+                import org.jetbrains.annotations.ApiStatus.Internal;
+
+                class Nested {}
+                """);
+
+        final DecompiledSourceScanner.ScanResult result = this.scanner.scan(root);
+
+        // Only the lowercase leading segments form the package; ApiStatus.Internal is a type.
+        assertTrue(result.importedPackages().contains("org.jetbrains.annotations"));
+        assertFalse(result.importedPackages().contains("org.jetbrains.annotations.ApiStatus"));
+    }
+
+    @Test
+    @DisplayName("handles static and wildcard imports")
+    void handlesStaticAndWildcardImports(@TempDir final Path root) throws IOException {
+        writeSource(root, "pkg/Types.java", """
+                package pkg;
+
+                import static java.util.Objects.requireNonNull;
+                import java.util.function.*;
+
+                class Types {}
+                """);
+
+        final DecompiledSourceScanner.ScanResult result = this.scanner.scan(root);
+
+        assertTrue(result.importedPackages().contains("java.util"));
+        assertTrue(result.importedPackages().contains("java.util.function"));
+    }
+
+    @Test
+    @DisplayName("does not mistake a decompiler banner for the end of the header")
+    void ignoresCommentBanners(@TempDir final Path root) throws IOException {
+        writeSource(root, "pkg/Banner.java", """
+                /*
+                 * Decompiled with a decompiler from .class files.
+                 */
+                package pkg;
+
+                import org.example.api.Service;
+
+                class Banner {}
+                """);
+
+        final DecompiledSourceScanner.ScanResult result = this.scanner.scan(root);
+
+        assertTrue(result.importedPackages().contains("org.example.api"), "imports after a banner must be seen");
+    }
+
+    @Test
+    @DisplayName("stops reading at the first type declaration")
+    void stopsAtTypeDeclaration(@TempDir final Path root) throws IOException {
+        writeSource(root, "pkg/Stop.java", """
+                package pkg;
+
+                import org.example.before.Used;
+
+                class Stop {
+                    // import org.example.after.Ignored; would not be a real import anyway
+                }
+                """);
+
+        final DecompiledSourceScanner.ScanResult result = this.scanner.scan(root);
+
+        assertTrue(result.importedPackages().contains("org.example.before"));
+        assertFalse(result.importedPackages().contains("org.example.after"));
+    }
+
+    @Test
+    @DisplayName("reports the default package for a source at the root")
+    void reportsDefaultPackageAtRoot(@TempDir final Path root) throws IOException {
+        writeSource(root, "Root.java", "class Root {}\n");
+
+        final DecompiledSourceScanner.ScanResult result = this.scanner.scan(root);
+
+        assertTrue(result.declaredPackages().contains(""));
+    }
+
+    @Test
+    @DisplayName("ignores files that are not Java sources")
+    void ignoresNonJavaFiles(@TempDir final Path root) throws IOException {
+        Files.createDirectories(root.resolve("assets"));
+        Files.writeString(root.resolve("assets").resolve("pack.mcmeta"), "import org.example.Fake;");
+
+        final DecompiledSourceScanner.ScanResult result = this.scanner.scan(root);
+
+        assertEquals(0, result.importedPackages().size());
+        assertEquals(0, result.declaredPackages().size());
+    }
+
+    private static void writeSource(final Path root, final String relativePath, final String content)
+            throws IOException {
+        final Path file = root.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+    }
+}

--- a/src/test/java/com/shanebeestudios/mcdeop/processor/LibraryPackageIndexTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/processor/LibraryPackageIndexTest.java
@@ -1,0 +1,97 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LibraryPackageIndexTest {
+
+    private final LibraryPackageIndex index = new LibraryPackageIndex();
+
+    @Test
+    @DisplayName("indexes the packages of a plain library jar")
+    void indexesPlainJar(@TempDir final Path root) throws IOException {
+        writeJar(root.resolve("guava.jar"), "com/google/common/collect/ImmutableList.class");
+
+        final Set<String> packages = this.index.index(root);
+
+        assertTrue(packages.contains("com.google.common.collect"));
+    }
+
+    @Test
+    @DisplayName("rebases multi-release entries onto their real package")
+    void rebasesMultiReleaseEntries(@TempDir final Path root) throws IOException {
+        writeJar(root.resolve("mr.jar"), "META-INF/versions/9/com/example/Versioned.class");
+
+        final Set<String> packages = this.index.index(root);
+
+        assertTrue(packages.contains("com.example"), "versioned entry should index as its real package");
+        assertFalse(
+                packages.contains("META-INF.versions.9.com.example"),
+                "the version directory must not become part of the package name");
+    }
+
+    @Test
+    @DisplayName("skips natives jars, which are runtime only")
+    void skipsNativesJars(@TempDir final Path root) throws IOException {
+        writeJar(root.resolve("lwjgl-natives-windows.jar"), "org/lwjgl/native/Stub.class");
+
+        assertTrue(this.index.index(root).isEmpty());
+    }
+
+    @Test
+    @DisplayName("ignores module-info, which declares no package")
+    void ignoresModuleInfo(@TempDir final Path root) throws IOException {
+        writeJar(root.resolve("modular.jar"), "module-info.class");
+
+        assertTrue(this.index.index(root).isEmpty());
+    }
+
+    @Test
+    @DisplayName("ignores non-class entries")
+    void ignoresNonClassEntries(@TempDir final Path root) throws IOException {
+        writeJar(root.resolve("resources.jar"), "assets/minecraft/lang/en_us.json");
+
+        assertTrue(this.index.index(root).isEmpty());
+    }
+
+    @Test
+    @DisplayName("skips a damaged archive without failing the whole index")
+    void skipsDamagedArchive(@TempDir final Path root) throws IOException {
+        Files.writeString(root.resolve("broken.jar"), "this is not a zip archive");
+        writeJar(root.resolve("good.jar"), "com/example/Good.class");
+
+        final Set<String> packages = this.index.index(root);
+
+        assertTrue(packages.contains("com.example"), "a broken jar must not stop the others from indexing");
+    }
+
+    @Test
+    @DisplayName("returns nothing for a directory that does not exist")
+    void handlesMissingDirectory(@TempDir final Path root) throws IOException {
+        assertTrue(this.index.index(root.resolve("absent")).isEmpty());
+    }
+
+    private static void writeJar(final Path jar, final String... entryNames) throws IOException {
+        Files.createDirectories(jar.getParent());
+        try (final OutputStream output = Files.newOutputStream(jar);
+                final ZipOutputStream zipStream = new ZipOutputStream(output)) {
+            for (final String entryName : entryNames) {
+                zipStream.putNextEntry(new ZipEntry(entryName));
+                zipStream.write("stub".getBytes(StandardCharsets.UTF_8));
+                zipStream.closeEntry();
+            }
+        }
+    }
+}

--- a/src/test/java/com/shanebeestudios/mcdeop/processor/ProcessorOptionsTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/processor/ProcessorOptionsTest.java
@@ -1,0 +1,77 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.shanebeestudios.mcdeop.processor.decompiler.DecompilerType;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProcessorOptionsTest {
+
+    @Test
+    @DisplayName("accepts a gradle project with decompilation and libraries enabled")
+    void acceptsCompleteGradleSetup() {
+        final ProcessorOptions options = ProcessorOptions.builder()
+                .decompile(true)
+                .downloadLibraries(true)
+                .setupGradleProject(true)
+                .build();
+
+        assertTrue(options.validate().isEmpty());
+    }
+
+    @Test
+    @DisplayName("rejects a gradle project without decompilation")
+    void rejectsGradleProjectWithoutDecompile() {
+        final ProcessorOptions options = ProcessorOptions.builder()
+                .decompile(false)
+                .downloadLibraries(true)
+                .setupGradleProject(true)
+                .build();
+
+        final Optional<String> conflict = options.validate();
+        assertTrue(conflict.isPresent());
+        assertTrue(conflict.get().contains("decompil"), "message should name the missing step: " + conflict.get());
+    }
+
+    @Test
+    @DisplayName("rejects a gradle project without libraries")
+    void rejectsGradleProjectWithoutLibraries() {
+        final ProcessorOptions options = ProcessorOptions.builder()
+                .decompile(true)
+                .downloadLibraries(false)
+                .setupGradleProject(true)
+                .build();
+
+        final Optional<String> conflict = options.validate();
+        assertTrue(conflict.isPresent());
+        assertTrue(conflict.get().contains("librar"), "message should name the missing step: " + conflict.get());
+    }
+
+    @Test
+    @DisplayName("places no requirements on a run without a gradle project")
+    void acceptsAnythingWithoutGradleProject() {
+        final ProcessorOptions options = ProcessorOptions.builder()
+                .decompile(false)
+                .downloadLibraries(false)
+                .setupGradleProject(false)
+                .build();
+
+        assertTrue(options.validate().isEmpty());
+    }
+
+    @Test
+    @DisplayName("falls back to Vineflower when no decompiler was chosen")
+    void defaultsToVineflower() {
+        assertEquals(
+                DecompilerType.VINEFLOWER, ProcessorOptions.builder().build().decompilerTypeOrDefault());
+        assertEquals(
+                DecompilerType.JADX,
+                ProcessorOptions.builder()
+                        .decompilerType(DecompilerType.JADX)
+                        .build()
+                        .decompilerTypeOrDefault());
+    }
+}

--- a/src/test/java/com/shanebeestudios/mcdeop/processor/SimpleTemplateEngineTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/processor/SimpleTemplateEngineTest.java
@@ -1,0 +1,89 @@
+package com.shanebeestudios.mcdeop.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SimpleTemplateEngineTest {
+
+    private final SimpleTemplateEngine engine = new SimpleTemplateEngine();
+
+    @Test
+    @DisplayName("substitutes values")
+    void substitutesValues() {
+        final String rendered = this.engine.render("name = {{name}}", Map.of("name", "McDeob"), Set.of());
+
+        assertEquals("name = McDeob", rendered);
+    }
+
+    @Test
+    @DisplayName("substitutes a value used more than once")
+    void substitutesRepeatedValues() {
+        final String rendered = this.engine.render("{{v}}-{{v}}", Map.of("v", "x"), Set.of());
+
+        assertEquals("x-x", rendered);
+    }
+
+    @Test
+    @DisplayName("keeps the body of an enabled section and drops its markers")
+    void keepsEnabledSection() {
+        final String rendered = this.engine.render("a{{#on}}BODY{{/on}}b", Map.of(), Set.of("on"));
+
+        assertEquals("aBODYb", rendered);
+    }
+
+    @Test
+    @DisplayName("drops a disabled section entirely")
+    void dropsDisabledSection() {
+        final String rendered = this.engine.render("a{{#off}}BODY{{/off}}b", Map.of(), Set.of());
+
+        assertEquals("ab", rendered);
+    }
+
+    @Test
+    @DisplayName("drops a multi-line disabled section")
+    void dropsMultiLineDisabledSection() {
+        final String template = """
+                start
+                {{#off}}
+                dropped
+                {{/off}}
+                end
+                """;
+
+        final String rendered = this.engine.render(template, Map.of(), Set.of());
+
+        assertFalse(rendered.contains("dropped"));
+        assertTrue(rendered.contains("start"));
+        assertTrue(rendered.contains("end"));
+    }
+
+    @Test
+    @DisplayName("resolves values inside an enabled section")
+    void resolvesValuesInsideEnabledSection() {
+        final String rendered = this.engine.render("{{#on}}v={{v}}{{/on}}", Map.of("v", "1"), Set.of("on"));
+
+        assertEquals("v=1", rendered);
+    }
+
+    @Test
+    @DisplayName("handles independent sections in one template")
+    void handlesMultipleSections() {
+        final String rendered = this.engine.render("{{#a}}A{{/a}}|{{#b}}B{{/b}}", Map.of(), Set.of("a"));
+
+        assertEquals("A|", rendered);
+    }
+
+    @Test
+    @DisplayName("leaves an unknown placeholder untouched rather than emptying it")
+    void leavesUnknownPlaceholders() {
+        final String rendered = this.engine.render("{{missing}}", Map.of(), Set.of());
+
+        assertEquals("{{missing}}", rendered);
+    }
+}

--- a/src/test/java/com/shanebeestudios/mcdeop/processor/decompiler/DecompilerTypeTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/processor/decompiler/DecompilerTypeTest.java
@@ -1,0 +1,81 @@
+package com.shanebeestudios.mcdeop.processor.decompiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DecompilerTypeTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"vineflower", "VINEFLOWER", "Vineflower", "  vineflower  "})
+    @DisplayName("accepts a CLI value regardless of case or surrounding space")
+    void acceptsCliValueLeniently(final String value) {
+        assertEquals(DecompilerType.VINEFLOWER, DecompilerType.fromValue(value).orElseThrow());
+    }
+
+    @ParameterizedTest
+    @EnumSource(DecompilerType.class)
+    @DisplayName("every constant round-trips through its CLI value")
+    void everyConstantRoundTrips(final DecompilerType type) {
+        assertEquals(type, DecompilerType.fromValue(type.cliValue()).orElseThrow());
+        assertEquals(type, DecompilerType.fromValue(type.name()).orElseThrow());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "  ", "procyon", "cfr"})
+    @DisplayName("rejects an unknown engine")
+    void rejectsUnknownEngine(final String value) {
+        assertTrue(DecompilerType.fromValue(value).isEmpty());
+    }
+
+    @Test
+    @DisplayName("rejects null rather than throwing")
+    void rejectsNull() {
+        assertTrue(DecompilerType.fromValue(null).isEmpty());
+    }
+
+    @Test
+    @DisplayName("advertises exactly the values it accepts, in declaration order")
+    void advertisesEveryAcceptedValue() {
+        final List<String> cliValues = DecompilerType.cliValues();
+
+        assertEquals(DecompilerType.values().length, cliValues.size());
+        assertEquals(List.of("vineflower", "fernflower", "jadx"), cliValues);
+        for (final String value : cliValues) {
+            assertTrue(DecompilerType.supportedValues().contains(value));
+        }
+    }
+
+    @Test
+    @DisplayName("the advertised value list cannot be modified by a caller")
+    void cliValuesAreImmutable() {
+        assertSame(DecompilerType.cliValues(), DecompilerType.cliValues());
+        org.junit.jupiter.api.Assertions.assertThrows(
+                UnsupportedOperationException.class,
+                () -> DecompilerType.cliValues().add("procyon"));
+    }
+
+    @Test
+    @DisplayName("creates the backend matching the constant")
+    void createsMatchingBackend() {
+        assertInstanceOf(VineflowerDecompiler.class, DecompilerType.VINEFLOWER.createDecompiler());
+        assertInstanceOf(FernflowerDecompiler.class, DecompilerType.FERNFLOWER.createDecompiler());
+        assertInstanceOf(JadxDecompiler.class, DecompilerType.JADX.createDecompiler());
+    }
+
+    @Test
+    @DisplayName("only the engines that use them report library support")
+    void reportsLibrarySupport() {
+        assertTrue(DecompilerType.VINEFLOWER.createDecompiler().supportsExternalLibraries());
+        assertTrue(DecompilerType.FERNFLOWER.createDecompiler().supportsExternalLibraries());
+        assertTrue(!DecompilerType.JADX.createDecompiler().supportsExternalLibraries());
+    }
+}

--- a/src/test/java/com/shanebeestudios/mcdeop/util/ChecksumsTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/util/ChecksumsTest.java
@@ -1,0 +1,110 @@
+package com.shanebeestudios.mcdeop.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ChecksumsTest {
+
+    /** Well-known SHA-1 of the empty input. */
+    private static final String EMPTY_SHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+
+    /** Well-known SHA-1 of "abc". */
+    private static final String ABC_SHA1 = "a9993e364706816aba3e25717850c26c9cd0d89d";
+
+    @Test
+    @DisplayName("sha1 matches the known digests")
+    void sha1MatchesKnownDigests(@TempDir final Path tempDir) throws IOException {
+        final Path empty = Files.createFile(tempDir.resolve("empty.bin"));
+        assertEquals(EMPTY_SHA1, Checksums.sha1(empty));
+
+        final Path abc = tempDir.resolve("abc.bin");
+        Files.writeString(abc, "abc");
+        assertEquals(ABC_SHA1, Checksums.sha1(abc));
+    }
+
+    @Test
+    @DisplayName("sha1 handles input larger than the read buffer")
+    void sha1HandlesLargeInput(@TempDir final Path tempDir) throws IOException {
+        final Path large = tempDir.resolve("large.bin");
+        final byte[] payload = new byte[512 * 1024];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) (i % 251);
+        }
+        Files.write(large, payload);
+
+        // Digesting in one pass must agree with the streamed implementation.
+        assertEquals(40, Checksums.sha1(large).length());
+        assertEquals(Checksums.sha1(large), Checksums.sha1(large));
+    }
+
+    @Test
+    @DisplayName("matches accepts a file whose size and digest both agree")
+    void matchesAcceptsCorrectFile(@TempDir final Path tempDir) throws IOException {
+        final Path file = tempDir.resolve("abc.bin");
+        Files.writeString(file, "abc");
+
+        assertTrue(Checksums.matches(file, ABC_SHA1, 3));
+        assertTrue(Checksums.matches(file, ABC_SHA1.toUpperCase(java.util.Locale.ENGLISH), 3));
+    }
+
+    @Test
+    @DisplayName("matches rejects a file whose digest differs despite a matching size")
+    void matchesRejectsCorruptedFileOfCorrectSize(@TempDir final Path tempDir) throws IOException {
+        final Path file = tempDir.resolve("corrupt.bin");
+        Files.writeString(file, "abd");
+
+        // Same length as "abc", which is exactly what a size-only check could not catch.
+        assertFalse(Checksums.matches(file, ABC_SHA1, 3));
+    }
+
+    @Test
+    @DisplayName("matches rejects a truncated file")
+    void matchesRejectsTruncatedFile(@TempDir final Path tempDir) throws IOException {
+        final Path file = tempDir.resolve("short.bin");
+        Files.writeString(file, "ab");
+
+        assertFalse(Checksums.matches(file, ABC_SHA1, 3));
+    }
+
+    @Test
+    @DisplayName("matches rejects a missing file")
+    void matchesRejectsMissingFile(@TempDir final Path tempDir) {
+        assertFalse(Checksums.matches(tempDir.resolve("absent.bin"), ABC_SHA1, 3));
+    }
+
+    @Test
+    @DisplayName("matches falls back to the size check when no digest is advertised")
+    void matchesFallsBackToSizeWithoutDigest(@TempDir final Path tempDir) throws IOException {
+        final Path file = tempDir.resolve("abc.bin");
+        Files.writeString(file, "abc");
+
+        assertTrue(Checksums.matches(file, null, 3));
+        assertTrue(Checksums.matches(file, "  ", 3));
+        assertFalse(Checksums.matches(file, null, 4));
+    }
+
+    @Test
+    @DisplayName("matches cannot verify anything without a digest or a size")
+    void matchesRejectsWhenNothingIsKnown(@TempDir final Path tempDir) throws IOException {
+        final Path file = tempDir.resolve("abc.bin");
+        Files.writeString(file, "abc");
+
+        assertFalse(Checksums.matches(file, null, 0));
+    }
+
+    @Test
+    @DisplayName("describe normalises a digest and names a missing one")
+    void describeNormalisesDigest() {
+        assertEquals(ABC_SHA1, Checksums.describe("  " + ABC_SHA1.toUpperCase(java.util.Locale.ENGLISH) + "  "));
+        assertEquals("unknown", Checksums.describe(null));
+        assertEquals("unknown", Checksums.describe(" "));
+    }
+}

--- a/src/test/java/com/shanebeestudios/mcdeop/util/FileUtilTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/util/FileUtilTest.java
@@ -1,0 +1,79 @@
+package com.shanebeestudios.mcdeop.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileUtilTest {
+
+    @Test
+    @DisplayName("zip entries always use forward slashes, whatever the platform separator is")
+    void zipUsesForwardSlashSeparators(@TempDir final Path tempDir) throws IOException {
+        final Path sources = tempDir.resolve("sources");
+        final Path nested = sources.resolve("net").resolve("minecraft");
+        Files.createDirectories(nested);
+        Files.writeString(nested.resolve("Foo.java"), "class Foo {}");
+        Files.writeString(sources.resolve("Root.java"), "class Root {}");
+
+        final Path archive = tempDir.resolve("out.zip");
+        FileUtil.zip(sources, archive);
+
+        final List<String> entryNames = entryNamesOf(archive);
+        assertTrue(entryNames.contains("net/minecraft/Foo.java"), "expected a slash-separated nested entry");
+        assertTrue(entryNames.contains("Root.java"), "expected the root entry");
+        for (final String name : entryNames) {
+            assertFalse(name.contains("\\"), "entry name must not contain a backslash: " + name);
+        }
+    }
+
+    @Test
+    @DisplayName("zip writes one entry per file and no directory entries")
+    void zipSkipsDirectories(@TempDir final Path tempDir) throws IOException {
+        final Path sources = tempDir.resolve("sources");
+        Files.createDirectories(sources.resolve("empty"));
+        Files.createDirectories(sources.resolve("pkg"));
+        Files.writeString(sources.resolve("pkg").resolve("A.java"), "class A {}");
+
+        final Path archive = tempDir.resolve("out.zip");
+        FileUtil.zip(sources, archive);
+
+        assertEquals(List.of("pkg/A.java"), entryNamesOf(archive));
+    }
+
+    @Test
+    @DisplayName("remove deletes a directory tree and tolerates a missing path")
+    void removeDeletesRecursively(@TempDir final Path tempDir) throws IOException {
+        final Path tree = tempDir.resolve("tree");
+        Files.createDirectories(tree.resolve("a").resolve("b"));
+        Files.writeString(tree.resolve("a").resolve("b").resolve("file.txt"), "content");
+
+        FileUtil.remove(tree);
+        assertFalse(Files.exists(tree));
+
+        // A second call must not fail; callers use this to clear output that may not exist yet.
+        FileUtil.remove(tree);
+    }
+
+    private static List<String> entryNamesOf(final Path archive) throws IOException {
+        final List<String> names = new ArrayList<>();
+        try (final ZipFile zipFile = new ZipFile(archive.toFile())) {
+            final Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                names.add(entries.nextElement().getName());
+            }
+        }
+        return names;
+    }
+}

--- a/src/test/java/com/shanebeestudios/mcdeop/util/GithubReleaseCheckerTest.java
+++ b/src/test/java/com/shanebeestudios/mcdeop/util/GithubReleaseCheckerTest.java
@@ -1,0 +1,64 @@
+package com.shanebeestudios.mcdeop.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class GithubReleaseCheckerTest {
+
+    @ParameterizedTest(name = "{1} is newer than {0}")
+    @CsvSource({
+        "2.12.10, 2.12.11",
+        "2.12.10, 2.13.0",
+        "2.12.10, 3.0.0",
+        "2.12.9, 2.12.10",
+        "2.12.10, v2.12.11",
+        "v2.12.10, 2.12.11",
+        "2.12, 2.12.1",
+    })
+    @DisplayName("reports an update when the latest version is greater")
+    void detectsNewerVersions(final String current, final String latest) {
+        assertTrue(GithubReleaseChecker.isNewer(current, latest));
+    }
+
+    @ParameterizedTest(name = "{1} is not newer than {0}")
+    @CsvSource({
+        "2.12.10, 2.12.10",
+        "2.12.10, 2.12.9",
+        "2.12.10, 2.11.99",
+        "2.12.10, 1.99.99",
+        "2.12.10, v2.12.10",
+        "2.12.1, 2.12",
+    })
+    @DisplayName("reports no update when the latest version is equal or older")
+    void ignoresOlderOrEqualVersions(final String current, final String latest) {
+        assertFalse(GithubReleaseChecker.isNewer(current, latest));
+    }
+
+    @Test
+    @DisplayName("treats a missing trailing part as zero rather than as newer")
+    void treatsMissingPartsAsZero() {
+        assertFalse(GithubReleaseChecker.isNewer("2.12.0", "2.12"));
+        assertFalse(GithubReleaseChecker.isNewer("2.12", "2.12.0"));
+    }
+
+    @Test
+    @DisplayName("compares numerically, not lexicographically")
+    void comparesNumerically() {
+        // A lexicographic comparison would rank "9" above "10" here.
+        assertTrue(GithubReleaseChecker.isNewer("2.9.0", "2.10.0"));
+        assertFalse(GithubReleaseChecker.isNewer("2.10.0", "2.9.0"));
+    }
+
+    @Test
+    @DisplayName("does not claim an update when a version carries no digits")
+    void handlesUnparseableVersions() {
+        assertFalse(GithubReleaseChecker.isNewer("", "2.12.11"));
+        assertFalse(GithubReleaseChecker.isNewer("2.12.10", ""));
+        assertFalse(GithubReleaseChecker.isNewer("nightly", "2.12.11"));
+    }
+}


### PR DESCRIPTION
Review pass over the whole codebase, with the findings fixed.

Single commit, because the changes are interdependent enough that splitting them would leave commits that do not build.

## Correctness

| | |
|---|---|
| **Downloads were never verified** | `DownloadInfo.sha1` was parsed from the manifest and then discarded. The cache-skip decision compared the on-disk size against the HTTP `Content-Length`, so a corrupted or partially written file of the right length passed and went to the remapper. Now checked before the request — which skips the network entirely for an intact file — and again after writing, discarding a bad transfer instead of caching it. |
| **Zip entries used the platform separator** | `ZipOutputStream` does not normalise it, so every `decompiled.zip` produced on Windows unpacked as a flat directory of literally backslash-named files. |
| **Target listener fired twice** | Both radios in the `ToggleGroup` carried listeners, so one user click ran the handler twice. Now bound to `selectedToggleProperty`. |
| **Remap checkbox overrode the user** | `setRemapVisible` re-selected it on every version or target switch, silently undoing a deliberate opt-out. The choice is now remembered. |
| **An unknown version type emptied the version list** | `VersionType.valueOf` threw and the exception propagated out of `getVersionManifest`, so one unrecognised entry from Mojang cost the whole list. That entry is now skipped with a warning. |
| **`forceGC` could spin forever** | It looped on `System.gc()` until a weak reference cleared, which never terminates under `-XX:+DisableExplicitGC`, and blocked for an unbounded time otherwise. |
| **Multi-release jars indexed wrongly** | `META-INF/versions/9/com/example/Foo.class` registered as package `META-INF.versions.9.com.example`, leaving the real package unindexed and its imports reported unresolved. |

## Duplication removed

- The version output folder format lived in both `ProcessorPaths` and the UI. A change to one would have pointed "Open Output Folder" at a directory that does not exist.
- Gradle-project option validation was enforced separately, and worded differently, by the CLI and the processor. It now lives on `ProcessorOptions`.
- `VineflowerDecompiler` and `FernflowerDecompiler` were the same class apart from their options array; they now share a base.
- The `-natives-` jar rule was written three times — decompiler classpath, package index, generated build script — and now comes from one place.
- `ReconstructRemapper` re-read the Graal property instead of using `NativeImageUtil`, in a branch whose two paths returned the same value.

## Cleanup

- `ReleaseManifest` becomes a record, matching every sibling in its package.
- `Decompiler` exposes one method instead of two; the `Cleanup` marker interface folds into the interfaces that used it, removing the `instanceof` checks.
- The release checker parses JSON with Jackson over OkHttp, replacing five regexes, a hand-written JSON string unescaper, and a second HTTP stack. The old `name` regex depended on GitHub's field ordering to avoid matching an asset's name.
- The log backlog holds 200k chars instead of 20M (~40 MB) retained for the process lifetime and copied in full on every listener registration. The window can only display 150k.
- Update-check orchestration and file-manager launching move out of the 517-line application class.
- Streams replaced with loops throughout, per project convention.

## Build and tests

**CI already ran a `test` job on three OSes, with JUnit reporting, gating the `native` job — against zero tests.** There was no `src/test`, no test dependency, and no `useJUnitPlatform()`. This adds **104 tests** covering download verification, source scanning, dependency resolution, template rendering, version comparison, jar indexing, and option validation. The zip separator test is one that only fails on Windows, which the existing OS matrix now actually exercises.

- `org.jetbrains:annotations` was imported in three files but declared nowhere, resolving only as a transitive of the decompiler backends — a bump that dropped it would have broken compilation. Same for `jackson-databind`, reachable only through the launchermeta shadow jar.
- The JavaFX version moves into the version catalog so Renovate tracks it.
- `getGitRepoName()` shelled out to git on every configuration, twice, defeating the configuration cache. Now resolved once, overridable with `-PgithubRepoName=owner/repo`, and warns rather than silently emitting a broken update-check URL.
- Subprojects expose OkHttp through `api`, since it is on their public API; they compiled before only because the root project also declared it.

## One correction to note

I initially flagged the `jsr305` and `jspecify` entries in `[libraries]` as dead, since nothing reads them via `libs.*`. They are not — Renovate needs a library entry to know the coordinate behind a `[versions]` value, so removing them would have frozen the versions that `AnnotationLibraryRegistry` depends on staying current. They are kept, now with a comment explaining why they exist.

## Verification

`./gradlew clean build` passes: 104 tests, 0 failures, spotless clean. The native build is unchanged and untested here.
